### PR TITLE
Add exception handling during message resolving 

### DIFF
--- a/src/Carrot.Tests/ConsumedMessageBuilding.cs
+++ b/src/Carrot.Tests/ConsumedMessageBuilding.cs
@@ -29,6 +29,22 @@ namespace Carrot.Tests
         }
 
         [Fact]
+        public void ExceptionOnResolve()
+        {
+            const String type = "fake-type";
+            var serializationConfiguration = new SerializationConfiguration();
+            var resolver = new Mock<IMessageTypeResolver>();
+            resolver.Setup(_ => _.Resolve(It.Is<ConsumedMessageContext>(__ => __.MessageType == type)))
+                    .Throws<Exception>();
+            var builder = new ConsumedMessageBuilder(serializationConfiguration, resolver.Object);
+            var message = builder.Build(new BasicDeliverEventArgs
+            {
+                BasicProperties = new BasicProperties { Type = type }
+            });
+            Assert.IsType<UnresolvedMessage>(message);
+        }
+
+        [Fact]
         public void MissingContentType()
         {
             const String contentType = "application/null";

--- a/src/Carrot/Messages/ConsumedMessageBuilder.cs
+++ b/src/Carrot/Messages/ConsumedMessageBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using Carrot.Configuration;
 using Carrot.Serialization;
 using RabbitMQ.Client.Events;
@@ -19,7 +20,9 @@ namespace Carrot.Messages
         public ConsumedMessageBase Build(BasicDeliverEventArgs args)
         {
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
-            var binding = _resolver.Resolve(context);
+            MessageBinding binding;
+            try { binding = _resolver.Resolve(context); }
+            catch (Exception) { return new UnresolvedMessage(args); }
 
             if (binding is EmptyMessageBinding)
                 return new UnresolvedMessage(args);


### PR DESCRIPTION
I added an exception catch in ConsumedMessageBuilder object in order to return UnresolvedMessage when exception occurs resolving messages.
