### PR TITLE
ConsumedMessage constructor as protected internal for testability

### DIFF
--- a/src/Carrot/Messages/ConsumedMessage.generic.cs
+++ b/src/Carrot/Messages/ConsumedMessage.generic.cs
@@ -5,7 +5,7 @@ namespace Carrot.Messages
     public class ConsumedMessage<TMessage> : Message<TMessage>
         where TMessage : class
     {
-        internal ConsumedMessage(TMessage content, HeaderCollection headers, String consumerTag)
+        protected internal ConsumedMessage(TMessage content, HeaderCollection headers, String consumerTag)
         {
             Content = content;
             Headers = headers;


### PR DESCRIPTION
To improve testability of **Consumer** class, **ConsumedMessage** constructor visibility level has been extended to protected internal.
