### PR TITLE
Fix MediaType.Parse() method

### DIFF
--- a/src/Carrot.Tests/MediaTypeParsing.cs
+++ b/src/Carrot.Tests/MediaTypeParsing.cs
@@ -76,5 +76,11 @@ namespace Carrot.Tests
             Assert.NotEqual(a, c);
             Assert.NotEqual(a.GetHashCode(), c.GetHashCode());
         }
+
+        [Fact]
+        public void MediaTypeWithoutSubtype()
+        {
+            Assert.Equal("application", ContentNegotiator.MediaType.Parse("application").Type);
+        }
     }
 }

--- a/src/Carrot/Serialization/ContentNegotiator.cs
+++ b/src/Carrot/Serialization/ContentNegotiator.cs
@@ -303,11 +303,9 @@ namespace Carrot.Serialization
                                     .Select(_ => _.Trim())
                                     .ToArray();
 
-                var type = strings[0];
-
-                return strings.Length <= 0 
-                    ? new MediaType(type) 
-                    : new MediaType(type, RegistrationTree.Parse(strings[1].Trim()));
+                return strings.Length <= 1
+                    ? new MediaType(source)
+                    : new MediaType(strings[0], RegistrationTree.Parse(strings[1].Trim()));
             }
         }
     }


### PR DESCRIPTION
This PR fixes a bug in the implementation of the MediaType.Parse() method.