### PR TITLE
Add ContainsHeader method to check custom header presence

### DIFF
--- a/src/Carrot.Tests/MessageBuilding.cs
+++ b/src/Carrot.Tests/MessageBuilding.cs
@@ -74,6 +74,8 @@ namespace Carrot.Tests
         [Fact]
         public void CustomHeader()
         {
+            var key = "a";
+            var value = "b";
             var content = new Foo();
             var args = new BasicDeliverEventArgs
                            {
@@ -81,13 +83,16 @@ namespace Carrot.Tests
                                                      {
                                                          Headers = new Dictionary<String, Object>
                                                                        {
-                                                                           { "a", "b" }
+                                                                           { key, value }
                                                                        }
                                                      }
                            };
             var message = new FakeConsumedMessage(content, args);
+
             var actual = message.To<Foo>();
-            Assert.Equal("b", actual.Headers["a"]);
+
+            Assert.True(actual.ContainsHeader(key));
+            Assert.Equal(value, actual.Headers[key]);
         }
 
         private static BasicDeliverEventArgs FakeBasicDeliverEventArgs()

--- a/src/Carrot.Tests/MessageHeaders.cs
+++ b/src/Carrot.Tests/MessageHeaders.cs
@@ -151,5 +151,16 @@ namespace Carrot.Tests
             Assert.Equal(correlationId, headers.CorrelationId);
             Assert.Equal(messageId, headers.MessageId);
         }
+
+        [Fact]
+        public void ContainsHeader()
+        {
+            const String key = "foo";
+            var collection = new HeaderCollection();
+
+            collection.AddHeader(key, null);
+
+            Assert.True(collection.ContainsHeader(key));
+        }
     }
 }

--- a/src/Carrot.Tests/OutboundEnveloping.cs
+++ b/src/Carrot.Tests/OutboundEnveloping.cs
@@ -305,6 +305,19 @@ namespace Carrot.Tests
             Assert.Equal("18000", properties.Expiration);
         }
 
+        [Fact]
+        public void CustomHeader()
+        {
+            var message = new OutboundMessage<Bar>(new Bar());
+            const String key = "a";
+            const String value = "b";
+
+            message.AddHeader(key, value);
+
+            Assert.True(message.ContainsHeader(key));
+            Assert.Equal(value, message.Headers[key]);
+        }
+
         private static Mock<IMessageTypeResolver> StubResolver<TMessage>(TimeSpan? expiresAfter)
             where TMessage : class
         {

--- a/src/Carrot/Messages/HeaderCollection.cs
+++ b/src/Carrot/Messages/HeaderCollection.cs
@@ -137,5 +137,16 @@ namespace Carrot.Messages
             else
                 InternalDictionary[key] = value;
         }
+
+        public bool ContainsHeader(String key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (ReservedKeys.Contains(key))
+                throw new InvalidOperationException($"key '{key}' is reserved");
+
+            return InternalDictionary.ContainsKey(key);
+        }
     }
 }

--- a/src/Carrot/Messages/Message.cs
+++ b/src/Carrot/Messages/Message.cs
@@ -9,6 +9,8 @@ namespace Carrot.Messages
 
         public abstract HeaderCollection Headers { get; }
 
+        public Boolean ContainsHeader(String key) => Headers.ContainsHeader(key);
+
         Object IMessage.Content => Content;
     }
 }


### PR DESCRIPTION
Adds a ContainsHeader to HeaderCollection and also to container message classes, i. e. consumed and outbound message (resolves #22). 