### PR TITLE
Use a pool of outbound channels to avoid sharing a channel between publisher threads

### DIFF
--- a/src/Carrot.ChannelPoolSample/Carrot.ChannelPoolSample.csproj
+++ b/src/Carrot.ChannelPoolSample/Carrot.ChannelPoolSample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Carrot\Carrot.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Carrot.ChannelPoolSample/Foo.cs
+++ b/src/Carrot.ChannelPoolSample/Foo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Carrot.Configuration;
+
+namespace Carrot.BasicSample
+{
+    [MessageBinding("urn:message:foo")]
+    public class Foo
+    {
+        public Int32 Bar { get; set; }
+    }
+}

--- a/src/Carrot.ChannelPoolSample/Foo.cs
+++ b/src/Carrot.ChannelPoolSample/Foo.cs
@@ -7,5 +7,6 @@ namespace Carrot.BasicSample
     public class Foo
     {
         public Int32 Bar { get; set; }
+        public string Buzz { get; set; }
     }
 }

--- a/src/Carrot.ChannelPoolSample/FooConsumers.cs
+++ b/src/Carrot.ChannelPoolSample/FooConsumers.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+using Carrot.Messages;
+
+namespace Carrot.BasicSample
+{
+    internal class FooConsumer1 : Consumer<Foo>
+    {
+        public override Task ConsumeAsync(ConsumedMessage<Foo> message)
+        {
+            return Task.Factory
+                       .StartNew(() =>
+                                 {
+                                     Console.WriteLine("[{0}]received '{1}' by '{2}'",
+                                                       message.ConsumerTag,
+                                                       message.Headers.MessageId,
+                                                       GetType().Name);
+                                 });
+        }
+    }
+
+    internal class FooConsumer2 : Consumer<Foo>
+    {
+        public override Task ConsumeAsync(ConsumedMessage<Foo> message)
+        {
+            return Task.Factory
+                       .StartNew(() =>
+                                 {
+                                     Console.WriteLine("[{0}]received '{1}' by '{2}'",
+                                                       message.ConsumerTag,
+                                                       message.Headers.MessageId,
+                                                       GetType().Name);
+                                 });
+        }
+    }
+}

--- a/src/Carrot.ChannelPoolSample/Program.cs
+++ b/src/Carrot.ChannelPoolSample/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Carrot.Configuration;
 using Carrot.Fallback;
@@ -10,6 +11,16 @@ namespace Carrot.BasicSample
 {
     public class Program
     {
+        const string LoremIpsum = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin in nisi turpis. Ut dui diam, laoreet tincidunt quam vel, efficitur rhoncus dui. Vivamus vel ipsum velit. Fusce leo libero, imperdiet pharetra venenatis quis, semper et urna. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque quis risus cursus, bibendum urna at, finibus tellus. Nam tempor dui nec tincidunt ultrices. Fusce lobortis tincidunt feugiat. Proin eu risus et augue feugiat molestie id finibus risus. In ultricies commodo tellus eu mollis. Fusce pharetra imperdiet nulla, mattis scelerisque augue rhoncus a. In in nunc felis. Nulla facilisi. Integer auctor aliquet sapien vitae tincidunt.
+
+Etiam hendrerit lobortis mi. Proin posuere dictum massa, vitae sodales massa tempus ac. Vivamus vestibulum dolor eros, non laoreet mauris cursus vel. Ut id nibh molestie, ultrices ex a, auctor turpis. Pellentesque id ex eu velit tincidunt congue interdum sit amet urna. Sed fermentum sit amet magna a facilisis. Curabitur in sapien malesuada, commodo felis at, pharetra nisl. Mauris lacinia sapien a maximus tempus. Suspendisse semper varius quam id facilisis. Praesent consequat tincidunt odio, ac eleifend ipsum iaculis quis.
+
+Donec pellentesque ligula sed est condimentum efficitur. Phasellus blandit gravida tempus. Vestibulum eget diam est. Vivamus a maximus neque, ac posuere tellus. Maecenas pharetra eros sem, eget ultrices velit porttitor eget. Suspendisse condimentum, eros sit amet ultrices tincidunt, sapien justo vehicula tellus, in tristique neque dui nec orci. Aenean feugiat, urna ut molestie consectetur, ligula ipsum sollicitudin arcu, ultrices bibendum odio odio ac magna. Cras id elementum felis. Sed eget erat tristique, ullamcorper tortor vitae, ornare felis. Suspendisse dictum velit nec risus consectetur tempor. Aenean et tortor sed mi scelerisque volutpat. Duis sodales vestibulum diam, efficitur placerat mi consectetur non. Nullam in turpis sit amet tellus tempus semper eget et justo. Ut gravida ipsum in lorem luctus gravida. Praesent non lorem non tortor ultricies viverra.
+
+Vivamus eros ipsum, sagittis vitae dui vel, porttitor fermentum lorem. Pellentesque quis tellus at metus cursus molestie. Fusce luctus tellus a est malesuada congue. Nullam efficitur ipsum id lobortis bibendum. Ut hendrerit ut risus id fringilla. Suspendisse bibendum augue ut blandit ultrices. Fusce id dolor at elit semper semper.
+
+Vestibulum in vehicula ipsum. Aliquam efficitur diam quis eros varius, at placerat nunc condimentum. Fusce ante nibh, gravida vitae molestie condimentum, gravida ac justo. Ut posuere fermentum tortor, eget pretium mauris ultrices at. Curabitur consequat auctor massa, vel eleifend libero tristique et. Curabitur dictum venenatis malesuada. Ut placerat turpis neque, quis ornare magna lobortis ac. In pellentesque nulla justo, vitae fringilla tortor faucibus sed. Integer vel nisl condimentum, aliquam sem eget, interdum diam. Aliquam gravida pharetra libero eget feugiat. Vivamus id neque et lectus rhoncus convallis.";
+
         private static void Main()
         {
             const String routingKey = "routing_key";
@@ -20,7 +31,7 @@ namespace Carrot.BasicSample
                                     {
                                         _.Endpoint(new Uri(endpointUrl, UriKind.Absolute));
                                         _.ResolveMessageTypeBy(resolver);
-                                        //_.PublishBy(OutboundChannel.Reliable());
+                                        _.PublishBy(OutboundChannel.Reliable());
                                     });
 
             var exchange = broker.DeclareDirectExchange("source_exchange");
@@ -49,10 +60,8 @@ namespace Carrot.BasicSample
 
         private static async Task DoPublish(IConnection connection, Exchange exchange, string routingKey, int count)
         {
-            //Console.WriteLine("Before publishing all");
             await Task.WhenAll(Enumerable.Range(0, count).Select(i =>
-                connection.PublishAsync(new OutboundMessage<Foo>(new Foo {Bar = i}), exchange, routingKey)));
-            //Console.WriteLine("After publishing all");
+                connection.PublishAsync(new OutboundMessage<Foo>(new Foo {Bar = i, Buzz = LoremIpsum }), exchange, routingKey)));
         }
     }
 }

--- a/src/Carrot.ChannelPoolSample/Program.cs
+++ b/src/Carrot.ChannelPoolSample/Program.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Carrot.Configuration;
+using Carrot.Fallback;
+using Carrot.Messages;
+
+namespace Carrot.BasicSample
+{
+    public class Program
+    {
+        private static void Main()
+        {
+            const String routingKey = "routing_key";
+            const String endpointUrl = "amqp://guest:guest@localhost:5672/";
+            IMessageTypeResolver resolver = new MessageBindingResolver(typeof(Foo).GetTypeInfo().Assembly);
+
+            var broker = Broker.New(_ =>
+                                    {
+                                        _.Endpoint(new Uri(endpointUrl, UriKind.Absolute));
+                                        _.ResolveMessageTypeBy(resolver);
+                                        //_.PublishBy(OutboundChannel.Reliable());
+                                    });
+
+            var exchange = broker.DeclareDirectExchange("source_exchange");
+            var queue = broker.DeclareQueue("my_test_queue");
+            broker.DeclareExchangeBinding(exchange, queue, routingKey);
+            broker.SubscribeByAtLeastOnce(queue,
+                                          _ =>
+                                          {
+                                              _.FallbackBy((c, a) => DeadLetterStrategy.New(c, a, x => $"{x}-Error"));
+                                              _.Consumes(new FooConsumer1());
+                                          });
+            broker.SubscribeByAtLeastOnce(queue,
+                                          _ =>
+                                          {
+                                              _.FallbackBy((c, a) => DeadLetterStrategy.New(c, a, x => $"{x}-Error"));
+                                              _.Consumes(new FooConsumer2());
+                                          });
+            var connection = broker.Connect();
+
+            var tasks = Enumerable.Range(0, 128).Select(i => Task.Run(() => DoPublish(connection, exchange, routingKey, 256)));
+            Task.WhenAll(tasks);
+
+            Console.ReadLine();
+            connection.Dispose();
+        }
+
+        private static async Task DoPublish(IConnection connection, Exchange exchange, string routingKey, int count)
+        {
+            //Console.WriteLine("Before publishing all");
+            await Task.WhenAll(Enumerable.Range(0, count).Select(i =>
+                connection.PublishAsync(new OutboundMessage<Foo>(new Foo {Bar = i}), exchange, routingKey)));
+            //Console.WriteLine("After publishing all");
+        }
+    }
+}

--- a/src/Carrot.Tests/AtLeastOnceReplying.cs
+++ b/src/Carrot.Tests/AtLeastOnceReplying.cs
@@ -93,7 +93,7 @@ namespace Carrot.Tests
             builder.Setup(_ => _.Build(args)).Returns(message);
             var channel = new Mock<IInboundChannel>();
             var consumer = new AtLeastOnceConsumerWrapper(channel.Object,
-                                                          new Mock<IOutboundChannel>().Object,
+                                                          new Mock<IOutboundChannelPool>().Object,
                                                           default(Queue),
                                                           builder.Object,
                                                           configuration);
@@ -131,11 +131,11 @@ namespace Carrot.Tests
         internal class AtLeastOnceConsumerWrapper : AtLeastOnceConsumer
         {
             internal AtLeastOnceConsumerWrapper(IInboundChannel inboundChannel,
-                                                IOutboundChannel outboundChannel,
+                                                IOutboundChannelPool outboundChannelPool,
                                                 Queue queue,
                                                 IConsumedMessageBuilder builder,
                                                 ConsumingConfiguration configuration)
-                : base(inboundChannel, outboundChannel, queue, builder, configuration)
+                : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
             {
             }
 

--- a/src/Carrot.Tests/AtMostOnceReplying.cs
+++ b/src/Carrot.Tests/AtMostOnceReplying.cs
@@ -26,7 +26,7 @@ namespace Carrot.Tests
             inboundChannel.Setup(_ => _.Acknowledge(deliveryTag)).Throws(new Exception());
             var builder = new Mock<IConsumedMessageBuilder>();
             var consumer = new AtMostOnceConsumerWrapper(inboundChannel.Object,
-                                                         new Mock<IOutboundChannel>().Object,
+                                                         new Mock<IOutboundChannelPool>().Object,
                                                          default(Queue),
                                                          builder.Object,
                                                          _configuration);
@@ -42,11 +42,11 @@ namespace Carrot.Tests
         internal class AtMostOnceConsumerWrapper : AtMostOnceConsumer
         {
             internal AtMostOnceConsumerWrapper(IInboundChannel inboundChannel,
-                                               IOutboundChannel outboundChannel,
+                                               IOutboundChannelPool outboundChannelPool,
                                                Queue queue,
                                                IConsumedMessageBuilder builder,
                                                ConsumingConfiguration configuration)
-                : base(inboundChannel, outboundChannel, queue, builder, configuration)
+                : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
             {
             }
 

--- a/src/Carrot.Tests/MessageHeaders.cs
+++ b/src/Carrot.Tests/MessageHeaders.cs
@@ -50,8 +50,8 @@ namespace Carrot.Tests
             const String value = "bar";
             collection.AddHeader(key, value);
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>()).Returns(EmptyMessageBinding.Instance);
             var message = new OutboundMessage<Foo>(new Foo(), collection);
+            resolver.Setup(_ => _.Resolve(message.Content)).Returns(EmptyMessageBinding.Instance);
             var properties = message.BuildBasicProperties(resolver.Object, null, null);
 
             Assert.Equal(messageId, properties.MessageId);
@@ -78,13 +78,13 @@ namespace Carrot.Tests
             const String key = "foo";
             const String value = "bar";
             collection.AddHeader(key, value);
+            var message = new OutboundMessage<Foo>(new Foo(), collection);
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>()).Returns(EmptyMessageBinding.Instance);
+            resolver.Setup(_ => _.Resolve(message.Content)).Returns(EmptyMessageBinding.Instance);
             var newId = new Mock<INewId>();
             newId.Setup(_ => _.Next()).Returns(messageId);
             var dateTimeProvider = new Mock<IDateTimeProvider>();
             dateTimeProvider.Setup(_ => _.UtcNow()).Returns(timestamp.ToDateTimeOffset());
-            var message = new OutboundMessage<Foo>(new Foo(), collection);
             var properties = message.BuildBasicProperties(resolver.Object, dateTimeProvider.Object, newId.Object);
 
             Assert.Equal(messageId, properties.MessageId);

--- a/src/Carrot.Tests/MessageResolving.cs
+++ b/src/Carrot.Tests/MessageResolving.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Carrot.Configuration;
 using Carrot.Messages;
@@ -38,8 +39,9 @@ namespace Carrot.Tests
         public void ResolveType()
         {
             var type = typeof(Foo);
+            var message = new OutboundMessage<Foo>(new Foo());
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
-            var binding = resolver.Resolve<Foo>();
+            var binding = resolver.Resolve(message.Content);
             Assert.Equal("urn:message:foo", binding.RawName);
             Assert.False(binding.ExpiresAfter.HasValue);
         }
@@ -48,8 +50,9 @@ namespace Carrot.Tests
         public void FallbackResolveType()
         {
             var type = typeof(Bar);
+            var message = new OutboundMessage<Bar>(new Bar());
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
-            var binding = resolver.Resolve<Bar>();
+            var binding = resolver.Resolve(message.Content);
             Assert.Equal("urn:message:Carrot.Tests.Bar", binding.RawName);
         }
 
@@ -57,8 +60,9 @@ namespace Carrot.Tests
         public void SettingExpiration()
         {
             var type = typeof(Buzz);
+            var message = new OutboundMessage<Buzz>(new Buzz());
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
-            var binding = resolver.Resolve<Buzz>();
+            var binding = resolver.Resolve(message.Content);
             Assert.Equal("urn:message:buzz", binding.RawName);
             Assert.Equal(TimeSpan.FromSeconds(19), binding.ExpiresAfter);
         }
@@ -69,12 +73,13 @@ namespace Carrot.Tests
             const String typeName = "Carrot.Tests.Foo";
             var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = typeName } };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
+            var message = new OutboundMessage<Foo>(new Foo());
             var resolver = new DefaultMessageTypeResolver(typeof(Foo).Assembly);
             var binding = resolver.Resolve(context);
             Assert.Equal(typeName, binding.RawName);
             Assert.Equal(typeof(Foo), binding.RuntimeType);
 
-            var binding2 = resolver.Resolve<Foo>();
+            var binding2 = resolver.Resolve(message.Content);
             Assert.Equal(typeName, binding2.RawName);
             Assert.Equal(typeof(Foo), binding2.RuntimeType);
         }

--- a/src/Carrot.Tests/OutboundEnveloping.cs
+++ b/src/Carrot.Tests/OutboundEnveloping.cs
@@ -24,7 +24,7 @@ namespace Carrot.Tests
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>())
+            resolver.Setup(_ => _.Resolve(message.Content))
                     .Returns(new MessageBinding(String.Empty,
                                                 typeof(Foo).GetTypeInfo()));
             configuration.ResolveMessageTypeBy(resolver.Object);
@@ -50,7 +50,7 @@ namespace Carrot.Tests
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>())
+            resolver.Setup(_ => _.Resolve(message.Content))
                     .Returns(new MessageBinding(String.Empty,
                                                 typeof(Foo).GetTypeInfo()));
             configuration.ResolveMessageTypeBy(resolver.Object);
@@ -83,7 +83,7 @@ namespace Carrot.Tests
 
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>())
+            resolver.Setup(_ => _.Resolve(message.Content))
                     .Returns(new MessageBinding(String.Empty,
                                                 typeof(Foo).GetTypeInfo()));
             configuration.ResolveMessageTypeBy(resolver.Object);
@@ -107,7 +107,7 @@ namespace Carrot.Tests
             var fallbackHandled = false;
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>())
+            resolver.Setup(_ => _.Resolve(message.Content))
                     .Returns(new MessageBinding(String.Empty,
                                                 typeof(Foo).GetTypeInfo()));
             configuration.ResolveMessageTypeBy(resolver.Object);
@@ -138,7 +138,7 @@ namespace Carrot.Tests
             newId.Setup(_ => _.Next()).Returns(messageId);
 
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<Foo>())
+            resolver.Setup(_ => _.Resolve(message.Content))
                     .Returns(new MessageBinding("urn:message:fake",
                                                 typeof(Foo).GetTypeInfo()));
 
@@ -153,7 +153,7 @@ namespace Carrot.Tests
         public void MessageType()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("urn:message:fake", properties.Type);
@@ -165,7 +165,7 @@ namespace Carrot.Tests
             const String contentEncoding = "UTF-16";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetContentEncoding(contentEncoding);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(contentEncoding, properties.ContentEncoding);
@@ -175,7 +175,7 @@ namespace Carrot.Tests
         public void DefaultContentEncoding()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("UTF-8", properties.ContentEncoding);
@@ -187,7 +187,7 @@ namespace Carrot.Tests
             const String contentType = "application/xml";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetContentType(contentType);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(contentType, properties.ContentType);
@@ -197,7 +197,7 @@ namespace Carrot.Tests
         public void DefaultContentType()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("application/json", properties.ContentType);
@@ -209,7 +209,7 @@ namespace Carrot.Tests
             String correlationId = Guid.NewGuid().ToString();
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetCorrelationId(correlationId);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(correlationId, properties.CorrelationId);
@@ -222,7 +222,7 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new DirectReplyConfiguration(replyExchangeName, replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("direct", properties.ReplyToAddress.ExchangeType);
@@ -237,7 +237,7 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new DirectReplyConfiguration(replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("direct:///replyRoutingKey", properties.ReplyTo);
@@ -250,7 +250,7 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new TopicReplyConfiguration(replyExchangeName, replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("topic", properties.ReplyToAddress.ExchangeType);
@@ -265,7 +265,7 @@ namespace Carrot.Tests
             const String replyExchangeName = "replyExchangeName";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new FanoutReplyConfiguration(replyExchangeName));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("fanout", properties.ReplyToAddress.ExchangeType);
@@ -278,7 +278,7 @@ namespace Carrot.Tests
         public void NonDurableMessage()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.False(properties.Persistent);
@@ -288,7 +288,7 @@ namespace Carrot.Tests
         public void DurableMessage()
         {
             var message = new DurableOutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.True(properties.Persistent);
@@ -299,17 +299,17 @@ namespace Carrot.Tests
         {
             var expiresAfter = new TimeSpan?(TimeSpan.FromSeconds(18));
             var message = new DurableOutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(expiresAfter).Object,
+            var properties = message.BuildBasicProperties(StubResolver(message, expiresAfter).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("18000", properties.Expiration);
         }
 
-        private static Mock<IMessageTypeResolver> StubResolver<TMessage>(TimeSpan? expiresAfter)
+        private static Mock<IMessageTypeResolver> StubResolver<TMessage>(OutboundMessage<TMessage> message, TimeSpan? expiresAfter)
             where TMessage : class
         {
             var resolver = new Mock<IMessageTypeResolver>();
-            resolver.Setup(_ => _.Resolve<TMessage>())
+            resolver.Setup(_ => _.Resolve(message.Content))
                     .Returns(new MessageBinding("urn:message:fake",
                                                 typeof(TMessage).GetTypeInfo(),
                              expiresAfter));

--- a/src/Carrot.Tests/ResourceManagement.cs
+++ b/src/Carrot.Tests/ResourceManagement.cs
@@ -17,29 +17,25 @@ namespace Carrot.Tests
         {
             var consumerChannel1 = new Mock<IInboundChannel>();
             var consumer1 = new FakeConsumerBase(consumerChannel1.Object,
-                                                 new Mock<IOutboundChannel>().Object,
+                                                 new Mock<IOutboundChannelPool>().Object,
                                                  default(Queue),
                                                  null,
                                                  null);
             var consumerChannel2 = new Mock<IInboundChannel>();
             var consumer2 = new FakeConsumerBase(consumerChannel2.Object,
-                                                 new Mock<IOutboundChannel>().Object,
+                                                 new Mock<IOutboundChannelPool>().Object,
                                                  default(Queue),
                                                  null,
                                                  null);
-            var outboundModel = new Mock<IModel>();
-            var connection = new Mock<RabbitMQ.Client.IConnection>();
             var outboundChannelPool = new Mock<IOutboundChannelPool>();
+            var connection = new Mock<RabbitMQ.Client.IConnection>();
             var amqpConnection = new Connection(connection.Object,
                                                 new List<ConsumerBase> { consumer1, consumer2 },
-                                                outboundChannelPool.Object,
-                                                new ReliableOutboundChannel(outboundModel.Object, null, null, null),
-                                                null);
+                                                outboundChannelPool.Object);
             amqpConnection.Dispose();
 
-            outboundChannelPool.Verify(_ => _.Dispose(), Times.Once);
             connection.Verify(_ => _.Dispose(), Times.Once);
-            outboundModel.Verify(_ => _.Dispose(), Times.Once);
+            outboundChannelPool.Verify(_ => _.Dispose(), Times.Once);
             consumerChannel1.Verify(_ => _.Dispose(), Times.Once);
             consumerChannel2.Verify(_ => _.Dispose(), Times.Once);
         }
@@ -47,11 +43,11 @@ namespace Carrot.Tests
         internal class FakeConsumerBase : ConsumerBase
         {
             public FakeConsumerBase(IInboundChannel inboundChannel,
-                                    IOutboundChannel outboundChannel,
+                                    IOutboundChannelPool outboundChannelPool,
                                     Queue queue,
                                     IConsumedMessageBuilder builder,
                                     ConsumingConfiguration configuration)
-                : base(inboundChannel, outboundChannel, queue, builder, configuration)
+                : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
             {
             }
 

--- a/src/Carrot.Tests/ResourceManagement.cs
+++ b/src/Carrot.Tests/ResourceManagement.cs
@@ -29,12 +29,15 @@ namespace Carrot.Tests
                                                  null);
             var outboundModel = new Mock<IModel>();
             var connection = new Mock<RabbitMQ.Client.IConnection>();
+            var outboundChannelPool = new Mock<IOutboundChannelPool>();
             var amqpConnection = new Connection(connection.Object,
                                                 new List<ConsumerBase> { consumer1, consumer2 },
+                                                outboundChannelPool.Object,
                                                 new ReliableOutboundChannel(outboundModel.Object, null, null, null),
                                                 null);
             amqpConnection.Dispose();
 
+            outboundChannelPool.Verify(_ => _.Dispose(), Times.Once);
             connection.Verify(_ => _.Dispose(), Times.Once);
             outboundModel.Verify(_ => _.Dispose(), Times.Once);
             consumerChannel1.Verify(_ => _.Dispose(), Times.Once);

--- a/src/Carrot.sln
+++ b/src/Carrot.sln
@@ -11,17 +11,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "contrib", "contrib", "{E87A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "logging", "logging", "{0D082319-44EC-4AB5-8BD5-B97C8BFDCCB0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carrot.NLog", "Carrot.NLog\Carrot.NLog.csproj", "{B7F17E24-8A22-43B2-8E1A-0BAB13CDEC22}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carrot.NLog", "Carrot.NLog\Carrot.NLog.csproj", "{B7F17E24-8A22-43B2-8E1A-0BAB13CDEC22}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carrot.log4net", "Carrot.log4net\Carrot.log4net.csproj", "{C4ED0D57-6EB7-4498-9FBA-E7FFD6FC9B9F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carrot.log4net", "Carrot.log4net\Carrot.log4net.csproj", "{C4ED0D57-6EB7-4498-9FBA-E7FFD6FC9B9F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{6D68D9FB-A6F8-461A-84A7-F44D05BD7F84}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carrot.BasicSample", "Carrot.BasicSample\Carrot.BasicSample.csproj", "{A3E72B2E-77D9-4C18-824B-B9A4C52EDD05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carrot.BasicSample", "Carrot.BasicSample\Carrot.BasicSample.csproj", "{A3E72B2E-77D9-4C18-824B-B9A4C52EDD05}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carrot.Benchmarks", "Carrot.Benchmarks\Carrot.Benchmarks.csproj", "{4464D238-2B01-49F3-AE1F-31043B71D2C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carrot.Benchmarks", "Carrot.Benchmarks\Carrot.Benchmarks.csproj", "{4464D238-2B01-49F3-AE1F-31043B71D2C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carrot.RpcSample", "Carrot.RpcSample\Carrot.RpcSample.csproj", "{48B1014F-E8FE-40EC-91ED-B9F8AC960DBC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carrot.RpcSample", "Carrot.RpcSample\Carrot.RpcSample.csproj", "{48B1014F-E8FE-40EC-91ED-B9F8AC960DBC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution items", "{5B1FF2EE-B620-481A-B5D6-1698C57D8B52}"
 	ProjectSection(SolutionItems) = preProject
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 		..\LICENSE.txt = ..\LICENSE.txt
 		..\README.md = ..\README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carrot.ChannelPoolSample", "Carrot.ChannelPoolSample\Carrot.ChannelPoolSample.csproj", "{175A7402-DD18-4250-9F14-6BCF8364DBA1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -64,6 +66,10 @@ Global
 		{48B1014F-E8FE-40EC-91ED-B9F8AC960DBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48B1014F-E8FE-40EC-91ED-B9F8AC960DBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48B1014F-E8FE-40EC-91ED-B9F8AC960DBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{175A7402-DD18-4250-9F14-6BCF8364DBA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{175A7402-DD18-4250-9F14-6BCF8364DBA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{175A7402-DD18-4250-9F14-6BCF8364DBA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{175A7402-DD18-4250-9F14-6BCF8364DBA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -75,6 +81,7 @@ Global
 		{A3E72B2E-77D9-4C18-824B-B9A4C52EDD05} = {6D68D9FB-A6F8-461A-84A7-F44D05BD7F84}
 		{4464D238-2B01-49F3-AE1F-31043B71D2C9} = {6D68D9FB-A6F8-461A-84A7-F44D05BD7F84}
 		{48B1014F-E8FE-40EC-91ED-B9F8AC960DBC} = {6D68D9FB-A6F8-461A-84A7-F44D05BD7F84}
+		{175A7402-DD18-4250-9F14-6BCF8364DBA1} = {6D68D9FB-A6F8-461A-84A7-F44D05BD7F84}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12239951-1ADC-404C-BB3A-BDD8922AB082}

--- a/src/Carrot/AtLeastOnceConsumer.cs
+++ b/src/Carrot/AtLeastOnceConsumer.cs
@@ -8,11 +8,11 @@ namespace Carrot
     public class AtLeastOnceConsumer : ConsumerBase
     {
         internal AtLeastOnceConsumer(IInboundChannel inboundChannel,
-                                     IOutboundChannel outboundChannel,
+                                     IOutboundChannelPool outboundChannelPool,
                                      Queue queue,
                                      IConsumedMessageBuilder builder,
                                      ConsumingConfiguration configuration)
-            : base(inboundChannel, outboundChannel, queue, builder, configuration)
+            : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
         {
         }
 
@@ -20,7 +20,7 @@ namespace Carrot
         {
             return ConsumeAsync(args).ContinueWith(_ => _.Result
                                                          .Reply(InboundChannel,
-                                                                OutboundChannel,
+                                                                OutboundChannelPool,
                                                                 Configuration.FallbackStrategy))
                                      .ContinueWith(_ =>
                                                    {

--- a/src/Carrot/AtMostOnceConsumer.cs
+++ b/src/Carrot/AtMostOnceConsumer.cs
@@ -8,11 +8,11 @@ namespace Carrot
     public class AtMostOnceConsumer : ConsumerBase
     {
         internal AtMostOnceConsumer(IInboundChannel inboundChannel,
-                                    IOutboundChannel outboundChannel,
+                                    IOutboundChannelPool outboundChannelPool,
                                     Queue queue,
                                     IConsumedMessageBuilder builder,
                                     ConsumingConfiguration configuration)
-            : base(inboundChannel, outboundChannel, queue, builder, configuration)
+            : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
         {
         }
 

--- a/src/Carrot/Broker.cs
+++ b/src/Carrot/Broker.cs
@@ -221,6 +221,7 @@ namespace Carrot
         {
             var builder = new ConsumedMessageBuilder(_configuration.SerializationConfiguration,
                                                      _configuration.MessageTypeResolver);
+            var outboundChannelPool = new OutboundChannelPool(connection, _configuration);
             var outboundChannel = _configuration.OutboundChannelBuilder(outboundModel,
                                                                         _configuration);
             var consumers = _promises.Select(_ =>
@@ -239,6 +240,7 @@ namespace Carrot
 
             return new Connection(connection,
                                   consumers.Select(_ => _.Consumer),
+                                  outboundChannelPool,
                                   outboundChannel,
                                   _configuration);
         }

--- a/src/Carrot/Broker.cs
+++ b/src/Carrot/Broker.cs
@@ -145,11 +145,12 @@ namespace Carrot
         public IConnection Connect()
         {
             var connection = _connectionBuilder.CreateConnection(_configuration.EndpointUri);
-            var outboundModel = connection.CreateModel();
+            using (var channel = connection.CreateModel())
+            {
+                ApplyEntitiesDeclarations(channel);
+            }
 
-            ApplyEntitiesDeclarations(outboundModel);
-
-            return CreateConnection(connection, outboundModel);
+            return CreateConnection(connection);
         }
 
         public void SubscribeByAtMostOnce(Queue queue, Action<ConsumingConfiguration> configure)
@@ -216,21 +217,18 @@ namespace Carrot
                 binding.Declare(outboundModel);
         }
 
-        private IConnection CreateConnection(RabbitMQ.Client.IConnection connection,
-                                             IModel outboundModel)
+        private IConnection CreateConnection(RabbitMQ.Client.IConnection connection)
         {
             var builder = new ConsumedMessageBuilder(_configuration.SerializationConfiguration,
                                                      _configuration.MessageTypeResolver);
             var outboundChannelPool = new OutboundChannelPool(connection, _configuration);
-            var outboundChannel = _configuration.OutboundChannelBuilder(outboundModel,
-                                                                        _configuration);
             var consumers = _promises.Select(_ =>
                                                 {
                                                     var model = CreateInboundModel(connection,
                                                                                    _configuration.PrefetchSize,
                                                                                    _configuration.PrefetchCount);
                                                     var consumer = _(builder).BuildConsumer(new InboundChannel(model),
-                                                                                            outboundChannel);
+                                                                                            outboundChannelPool);
                                                     return new { Model = model, Consumer = consumer };
                                                 })
                                      .ToList();
@@ -240,9 +238,7 @@ namespace Carrot
 
             return new Connection(connection,
                                   consumers.Select(_ => _.Consumer),
-                                  outboundChannelPool,
-                                  outboundChannel,
-                                  _configuration);
+                                  outboundChannelPool);
         }
     }
 }

--- a/src/Carrot/Configuration/DefaultMessageTypeResolver.cs
+++ b/src/Carrot/Configuration/DefaultMessageTypeResolver.cs
@@ -27,9 +27,9 @@ namespace Carrot.Configuration
                        : new MessageBinding(messageType, type.GetTypeInfo());
         }
 
-        public MessageBinding Resolve<TMessage>() where TMessage : class
+        public MessageBinding Resolve<TMessage>(TMessage message) where TMessage : class
         {
-            var type = typeof(TMessage).GetTypeInfo();
+            var type = message.GetType().GetTypeInfo();
 
             return new MessageBinding(type.FullName, type);
         }

--- a/src/Carrot/Configuration/IMessageTypeResolver.cs
+++ b/src/Carrot/Configuration/IMessageTypeResolver.cs
@@ -6,6 +6,6 @@ namespace Carrot.Configuration
     {
         MessageBinding Resolve(ConsumedMessageContext context);
 
-        MessageBinding Resolve<TMessage>() where TMessage : class;
+        MessageBinding Resolve<TMessage>(TMessage message) where TMessage : class;
     }
 }

--- a/src/Carrot/Configuration/MessageBindingResolver.cs
+++ b/src/Carrot/Configuration/MessageBindingResolver.cs
@@ -30,9 +30,9 @@ namespace Carrot.Configuration
                        : EmptyMessageBinding.Instance;
         }
 
-        public MessageBinding Resolve<TMessage>() where TMessage : class
+        public MessageBinding Resolve<TMessage>(TMessage message) where TMessage : class
         {
-            var type = typeof(TMessage).GetTypeInfo();
+            var type = message.GetType().GetTypeInfo();
             var attribute = type.GetCustomAttribute<MessageBindingAttribute>();
 
             return BuildMessageBinding(attribute != null

--- a/src/Carrot/Connection.cs
+++ b/src/Carrot/Connection.cs
@@ -8,29 +8,49 @@ namespace Carrot
 {
     public class Connection : IConnection
     {
+        private volatile int _count; // TODO: remove me, for testing only
+
         protected readonly EnvironmentConfiguration Configuration;
 
         private readonly RabbitMQ.Client.IConnection _connection;
         private readonly IEnumerable<ConsumerBase> _consumers;
+        private readonly IOutboundChannelPool _outboundChannelPool;
         private readonly IOutboundChannel _outboundChannel;
 
         internal Connection(RabbitMQ.Client.IConnection connection,
                             IEnumerable<ConsumerBase> consumers,
+                            IOutboundChannelPool outboundChannelPool,
                             IOutboundChannel outboundChannel,
                             EnvironmentConfiguration configuration)
         {
             _connection = connection;
             _consumers = consumers;
+            _outboundChannelPool = outboundChannelPool;
             _outboundChannel = outboundChannel;
             Configuration = configuration;
         }
-        
+
         public Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> message,
-                                                           Exchange exchange,
-                                                           String routingKey = "")
+            Exchange exchange,
+            String routingKey = "")
             where TMessage : class
         {
-            return _outboundChannel.PublishAsync(message, exchange, routingKey);
+            _count++;
+            //return Task.Run(() =>
+            //{
+                var outboundChannel = _outboundChannelPool.Take();
+                try
+                {
+                    //Console.WriteLine($"Before _outboundChannel.PublishAsync to {_count}");
+                    var publishAsync = outboundChannel.PublishAsync(message, exchange, routingKey);
+                    //Console.WriteLine($"After _outboundChannel.PublishAsync to {_count}");
+                    return publishAsync;
+                }
+                finally
+                {
+                    _outboundChannelPool.Add(outboundChannel);
+                }
+            //});
         }
 
         public void Dispose()
@@ -38,6 +58,7 @@ namespace Carrot
             foreach (var consumer in _consumers)
                 consumer.Dispose();
 
+            _outboundChannelPool?.Dispose();
             _outboundChannel?.Dispose();
             _connection?.Dispose();
         }

--- a/src/Carrot/Connection.cs
+++ b/src/Carrot/Connection.cs
@@ -8,49 +8,33 @@ namespace Carrot
 {
     public class Connection : IConnection
     {
-        private volatile int _count; // TODO: remove me, for testing only
-
-        protected readonly EnvironmentConfiguration Configuration;
-
         private readonly RabbitMQ.Client.IConnection _connection;
         private readonly IEnumerable<ConsumerBase> _consumers;
         private readonly IOutboundChannelPool _outboundChannelPool;
-        private readonly IOutboundChannel _outboundChannel;
 
         internal Connection(RabbitMQ.Client.IConnection connection,
                             IEnumerable<ConsumerBase> consumers,
-                            IOutboundChannelPool outboundChannelPool,
-                            IOutboundChannel outboundChannel,
-                            EnvironmentConfiguration configuration)
+                            IOutboundChannelPool outboundChannelPool)
         {
             _connection = connection;
             _consumers = consumers;
             _outboundChannelPool = outboundChannelPool;
-            _outboundChannel = outboundChannel;
-            Configuration = configuration;
         }
 
         public Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> message,
-            Exchange exchange,
-            String routingKey = "")
+                                                           Exchange exchange,
+                                                           String routingKey = "")
             where TMessage : class
         {
-            _count++;
-            //return Task.Run(() =>
-            //{
-                var outboundChannel = _outboundChannelPool.Take();
-                try
-                {
-                    //Console.WriteLine($"Before _outboundChannel.PublishAsync to {_count}");
-                    var publishAsync = outboundChannel.PublishAsync(message, exchange, routingKey);
-                    //Console.WriteLine($"After _outboundChannel.PublishAsync to {_count}");
-                    return publishAsync;
-                }
-                finally
-                {
-                    _outboundChannelPool.Add(outboundChannel);
-                }
-            //});
+            var outboundChannel = _outboundChannelPool.Take();
+            try
+            {
+                return outboundChannel.PublishAsync(message, exchange, routingKey);
+            }
+            finally
+            {
+                _outboundChannelPool.Add(outboundChannel);
+            }
         }
 
         public void Dispose()
@@ -59,7 +43,6 @@ namespace Carrot
                 consumer.Dispose();
 
             _outboundChannelPool?.Dispose();
-            _outboundChannel?.Dispose();
             _connection?.Dispose();
         }
     }

--- a/src/Carrot/ConsumerBase.cs
+++ b/src/Carrot/ConsumerBase.cs
@@ -11,19 +11,19 @@ namespace Carrot
     {
         protected readonly ConsumingConfiguration Configuration;
         protected readonly IInboundChannel InboundChannel;
-        protected readonly IOutboundChannel OutboundChannel;
+        protected readonly IOutboundChannelPool OutboundChannelPool;
 
         private readonly Queue _queue;
         private readonly IConsumedMessageBuilder _builder;
 
         protected internal ConsumerBase(IInboundChannel inboundChannel,
-                                        IOutboundChannel outboundChannel,
+                                        IOutboundChannelPool outboundChannelPool,
                                         Queue queue,
                                         IConsumedMessageBuilder builder,
                                         ConsumingConfiguration configuration)
         {
             InboundChannel = inboundChannel;
-            OutboundChannel = outboundChannel;
+            OutboundChannelPool = outboundChannelPool;
             _queue = queue;
             _builder = builder;
             Configuration = configuration;

--- a/src/Carrot/ConsumingPromise.cs
+++ b/src/Carrot/ConsumingPromise.cs
@@ -23,7 +23,7 @@ namespace Carrot
             LogBuilder = logBuilder;
         }
 
-        internal abstract ConsumerBase BuildConsumer(IInboundChannel inboundChannel, IOutboundChannel outboundChannel);
+        internal abstract ConsumerBase BuildConsumer(IInboundChannel inboundChannel, IOutboundChannelPool outboundChannelPool);
     }
 
     internal class AtMostOnceConsumingPromise : ConsumingPromise
@@ -36,10 +36,10 @@ namespace Carrot
         {
         }
 
-        internal override ConsumerBase BuildConsumer(IInboundChannel inboundChannel, IOutboundChannel outboundChannel)
+        internal override ConsumerBase BuildConsumer(IInboundChannel inboundChannel, IOutboundChannelPool outboundChannelPool)
         {
             return new LoggedAtMostOnceConsumer(inboundChannel,
-                                                outboundChannel,
+                                                outboundChannelPool,
                                                 Queue,
                                                 Builder,
                                                 Configuration,
@@ -57,10 +57,10 @@ namespace Carrot
         {
         }
 
-        internal override ConsumerBase BuildConsumer(IInboundChannel inboundChannel, IOutboundChannel outboundChannel)
+        internal override ConsumerBase BuildConsumer(IInboundChannel inboundChannel, IOutboundChannelPool outboundChannelPool)
         {
             return new LoggedAtLeastOnceConsumer(inboundChannel,
-                                                 outboundChannel,
+                                                 outboundChannelPool,
                                                  Queue,
                                                  Builder,
                                                  Configuration,

--- a/src/Carrot/Fallback/DeadLetterStrategy.cs
+++ b/src/Carrot/Fallback/DeadLetterStrategy.cs
@@ -24,9 +24,17 @@ namespace Carrot.Fallback
             return new DeadLetterStrategy(broker.DeclareDurableDirectExchange(exchangeNameBuilder(queue.Name)));
         }
 
-        public void Apply(IOutboundChannel channel, ConsumedMessageBase message)
+        public void Apply(IOutboundChannelPool channelPool, ConsumedMessageBase message)
         {
-            channel.ForwardAsync(message, _exchange, String.Empty);
+            var channel = channelPool.Take();
+            try
+            {
+                channel.ForwardAsync(message, _exchange, String.Empty);
+            }
+            finally
+            {
+                channelPool.Add(channel);
+            }
         }
     }
 }

--- a/src/Carrot/Fallback/IFallbackStrategy.cs
+++ b/src/Carrot/Fallback/IFallbackStrategy.cs
@@ -4,6 +4,6 @@ namespace Carrot.Fallback
 {
     public interface IFallbackStrategy
     {
-        void Apply(IOutboundChannel channel, ConsumedMessageBase message);
+        void Apply(IOutboundChannelPool channelPool, ConsumedMessageBase message);
     }
 }

--- a/src/Carrot/Fallback/NoFallbackStrategy.cs
+++ b/src/Carrot/Fallback/NoFallbackStrategy.cs
@@ -8,6 +8,6 @@ namespace Carrot.Fallback
 
         private NoFallbackStrategy() { }
 
-        public void Apply(IOutboundChannel channel, ConsumedMessageBase message) { }
+        public void Apply(IOutboundChannelPool channelPool, ConsumedMessageBase message) { }
     }
 }

--- a/src/Carrot/IOutboundChannelPool.cs
+++ b/src/Carrot/IOutboundChannelPool.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Carrot
+{
+    public interface IOutboundChannelPool : IDisposable
+    {
+        IOutboundChannel Take();
+        void Add(IOutboundChannel channel);
+    }
+}

--- a/src/Carrot/LoggedAtLeastOnceConsumer.cs
+++ b/src/Carrot/LoggedAtLeastOnceConsumer.cs
@@ -13,12 +13,12 @@ namespace Carrot
         private readonly ILog _log;
 
         internal LoggedAtLeastOnceConsumer(IInboundChannel inboundChannel,
-                                           IOutboundChannel outboundChannel,
+                                           IOutboundChannelPool outboundChannelPool,
                                            Queue queue,
                                            IConsumedMessageBuilder builder,
                                            ConsumingConfiguration configuration,
                                            ILog log)
-            : base(inboundChannel, outboundChannel, queue, builder, configuration)
+            : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
         {
             _log = log;
         }

--- a/src/Carrot/LoggedAtMostOnceConsumer.cs
+++ b/src/Carrot/LoggedAtMostOnceConsumer.cs
@@ -13,12 +13,12 @@ namespace Carrot
         private readonly ILog _log;
 
         internal LoggedAtMostOnceConsumer(IInboundChannel inboundChannel,
-                                          IOutboundChannel outboundChannel,
+                                          IOutboundChannelPool outboundChannelPool,
                                           Queue queue,
                                           IConsumedMessageBuilder builder,
                                           ConsumingConfiguration configuration,
                                           ILog log)
-            : base(inboundChannel, outboundChannel, queue, builder, configuration)
+            : base(inboundChannel, outboundChannelPool, queue, builder, configuration)
         {
             _log = log;
         }

--- a/src/Carrot/Messages/OutboundMessage.cs
+++ b/src/Carrot/Messages/OutboundMessage.cs
@@ -79,7 +79,7 @@ namespace Carrot.Messages
             if (Headers.ReplyConfiguration != null)
                 properties.ReplyTo = Headers.ReplyConfiguration.ToString();
 
-            var binding = resolver.Resolve<TMessage>();
+            var binding = resolver.Resolve(Content);
             properties.Type = binding.RawName;
 
             if (binding.ExpiresAfter.HasValue)

--- a/src/Carrot/Messages/Results.cs
+++ b/src/Carrot/Messages/Results.cs
@@ -50,7 +50,7 @@ namespace Carrot.Messages
         }
 
         internal virtual AggregateConsumingResult Reply(IInboundChannel inboundChannel,
-                                                        IOutboundChannel outboundChannel,
+                                                        IOutboundChannelPool outboundChannelPool,
                                                         IFallbackStrategy fallbackStrategy)
         {
             Message.Acknowledge(inboundChannel);
@@ -105,11 +105,11 @@ namespace Carrot.Messages
         }
 
         internal override AggregateConsumingResult Reply(IInboundChannel inboundChannel,
-                                                         IOutboundChannel outboundChannel,
+                                                         IOutboundChannelPool outboundChannelPool,
                                                          IFallbackStrategy fallbackStrategy)
         {
-            fallbackStrategy.Apply(outboundChannel, Message);
-            return base.Reply(inboundChannel, outboundChannel, fallbackStrategy);
+            fallbackStrategy.Apply(outboundChannelPool, Message);
+            return base.Reply(inboundChannel, outboundChannelPool, fallbackStrategy);
         }
     }
 
@@ -123,7 +123,7 @@ namespace Carrot.Messages
         }
 
         internal override AggregateConsumingResult Reply(IInboundChannel inboundChannel,
-                                                         IOutboundChannel outboundChannel,
+                                                         IOutboundChannelPool outboundChannelPool,
                                                          IFallbackStrategy fallbackStrategy)
         {
             Message.Requeue(inboundChannel);

--- a/src/Carrot/OutboundChannelPool.cs
+++ b/src/Carrot/OutboundChannelPool.cs
@@ -4,7 +4,7 @@ using Carrot.Configuration;
 
 namespace Carrot
 {
-    public class OutboundChannelPool : IOutboundChannelPool
+    internal class OutboundChannelPool : IOutboundChannelPool
     {
         private readonly RabbitMQ.Client.IConnection _connection;
         private readonly EnvironmentConfiguration _configuration;

--- a/src/Carrot/OutboundChannelPool.cs
+++ b/src/Carrot/OutboundChannelPool.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Concurrent;
+using Carrot.Configuration;
+
+namespace Carrot
+{
+    public class OutboundChannelPool : IOutboundChannelPool
+    {
+        private readonly RabbitMQ.Client.IConnection _connection;
+        private readonly EnvironmentConfiguration _configuration;
+        private readonly ConcurrentBag<IOutboundChannel> _channels;
+
+        public OutboundChannelPool(RabbitMQ.Client.IConnection connection, EnvironmentConfiguration configuration)
+        {
+            _connection = connection;
+            _configuration = configuration;
+            _channels = new ConcurrentBag<IOutboundChannel>();
+        }
+
+        public IOutboundChannel Take()
+        {
+            IOutboundChannel channel;
+            if (!_channels.TryTake(out channel))
+            {
+                var model = _connection.CreateModel();
+                channel = _configuration.OutboundChannelBuilder(model, _configuration);
+            }
+
+            return channel;
+        }
+
+        public void Add(IOutboundChannel channel)
+        {
+            _channels.Add(channel);
+        }
+
+        public void Dispose()
+        {
+            IOutboundChannel channel;
+            while (_channels.TryTake(out channel))
+            {
+                channel.Dispose();
+            }
+        }
+    }
+}

--- a/src/Carrot/ReliableOutboundChannel.cs
+++ b/src/Carrot/ReliableOutboundChannel.cs
@@ -60,7 +60,7 @@ namespace Carrot
         {
             base.OnModelDisposing();
 
-            Model.WaitForConfirms(TimeSpan.FromSeconds(30d)); // TODO: timeout should not be hardcodeds
+            Model.WaitForConfirms(TimeSpan.FromSeconds(30d)); // TODO: timeout should not be hardcoded
             Model.BasicAcks -= OnModelBasicAcks;
             Model.BasicNacks -= OnModelBasicNacks;
         }


### PR DESCRIPTION
The upstream implementation uses a single IOutboundChannel, enclosing a single RabbitMQ's IModel, shared by all publish operations. This creates problems with publisher confirms, as a single channel must not be shared among publisher threads according to the RabbitMQ documentation.
This pull request introduces a pool of outbound channels that is used in place of a single outbound channel. Whenever a message is about to be published, a channel is taken from the pool, and it is returned to the pool afterwards, so that a thread makes exclusive use of a channel while publishing.
The pool is implemented as an unbounded concurrent bag where new channels are allocated as needed. Even if it is unbounded, it does not grow without control, staying within the same order of magnitude as the size of the system's thread pool (approx the number of CPU cores) if Tasks are used.

This pull requests also includes my previous p.r. #24 Resolving outbound message type at runtime on message instance.

Thanks,
   Salvo
-- 