### PR TITLE
PublishAsync now supports an exchange of type String.

### DIFF
--- a/src/Carrot.BasicSample/FooConsumers.cs
+++ b/src/Carrot.BasicSample/FooConsumers.cs
@@ -27,7 +27,7 @@ namespace Carrot.BasicSample
                                      return context.OutboundChannel
                                                    .PublishAsync<Foo>(new OutboundMessage<Foo>(context.Message
                                                                                                       .Content),
-                                                                      _exchange,
+                                                                      _exchange.Name,
                                                                       _routingKey);
                                  })
                        .Unwrap()

--- a/src/Carrot.BasicSample/Program.cs
+++ b/src/Carrot.BasicSample/Program.cs
@@ -11,7 +11,7 @@ namespace Carrot.BasicSample
         private static void Main()
         {
             const String routingKey = "routing_key";
-            const String endpointUrl = "amqp://guest:guest@localhost:5672/";
+            const String endpointUrl = "amqp://guest:guest@localhost:5674/";
             IMessageTypeResolver resolver = new MessageBindingResolver(typeof(Foo).GetTypeInfo().Assembly);
 
             var broker = Broker.New(_ =>

--- a/src/Carrot/IOutboundChannel.cs
+++ b/src/Carrot/IOutboundChannel.cs
@@ -11,8 +11,17 @@ namespace Carrot
                                                     String routingKey)
             where TMessage : class;
 
+        Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> source,
+                                                    String exchange,
+                                                    String routingKey)
+            where TMessage : class;
+
         Task<IPublishResult> ForwardAsync(ConsumedMessageBase message,
                                           Exchange exchange,
+                                          String routingKey);
+
+        Task<IPublishResult> ForwardAsync(ConsumedMessageBase message,
+                                          String exchange,
                                           String routingKey);
     }
 }

--- a/src/Carrot/OutboundChannel.cs
+++ b/src/Carrot/OutboundChannel.cs
@@ -45,8 +45,17 @@ namespace Carrot
             Model.Dispose();
         }
 
+
+
         public virtual Task<IPublishResult> ForwardAsync(ConsumedMessageBase message,
                                                          Exchange exchange,
+                                                         String routingKey)
+        {
+            return ForwardAsync(message, exchange.Name, routingKey);
+        }
+
+        public virtual Task<IPublishResult> ForwardAsync(ConsumedMessageBase message,
+                                                         String exchange,
                                                          String routingKey)
         {
             var properties = (IBasicProperties)(message.Args
@@ -60,6 +69,14 @@ namespace Carrot
 
         public virtual Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> source,
                                                                    Exchange exchange,
+                                                                   String routingKey)
+            where TMessage : class
+        {
+            return PublishAsync(source, exchange.Name, routingKey);
+        }
+
+        public virtual Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> source,
+                                                                   String exchange,
                                                                    String routingKey)
             where TMessage : class
         {
@@ -95,7 +112,7 @@ namespace Carrot
 
         protected virtual void OnModelDisposing() { }
 
-        private Task<IPublishResult> PublishInternalAsync(Exchange exchange,
+        private Task<IPublishResult> PublishInternalAsync(String exchange,
                                                           String routingKey,
                                                           IBasicProperties properties,
                                                           Byte[] body)
@@ -104,7 +121,7 @@ namespace Carrot
 
             try
             {
-                Model.BasicPublish(exchange.Name, routingKey, false, properties, body);
+                Model.BasicPublish(exchange, routingKey, false, properties, body);
                 tcs.TrySetResult(true);
             }
             catch (Exception exception) { tcs.TrySetException(exception); }

--- a/src/Carrot/ReliableOutboundChannel.cs
+++ b/src/Carrot/ReliableOutboundChannel.cs
@@ -32,6 +32,13 @@ namespace Carrot
                                                                     Exchange exchange,
                                                                     String routingKey)
         {
+            return PublishAsync(source, exchange.Name, routingKey);
+        }
+
+        public override Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> source,
+                                                                    String exchange,
+                                                                    String routingKey)
+        {
             var properties = BuildBasicProperties(source);
             var body = BuildBody(source, properties);
             var tcs = new TaskCompletionSource<Boolean>(properties);
@@ -40,7 +47,7 @@ namespace Carrot
 
             try
             {
-                Model.BasicPublish(exchange.Name,
+                Model.BasicPublish(exchange,
                                    routingKey,
                                    false,
                                    properties,


### PR DESCRIPTION
Strongly typing is encouraged, but we relax those constraints
for publishing. This way you're not forced to declare your
exchange if you have just to publish messages.
It should solve #32 