### PR TITLE
RabbitMQ driver update

### DIFF
--- a/src/Carrot.BasicSample/Carrot.BasicSample.csproj
+++ b/src/Carrot.BasicSample/Carrot.BasicSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.BasicSample/Program.cs
+++ b/src/Carrot.BasicSample/Program.cs
@@ -11,7 +11,7 @@ namespace Carrot.BasicSample
         private static void Main()
         {
             const String routingKey = "routing_key";
-            const String endpointUrl = "amqp://guest:guest@localhost:5674/";
+            const String endpointUrl = "amqp://guest:guest@localhost:5672/";
             IMessageTypeResolver resolver = new MessageBindingResolver(typeof(Foo).GetTypeInfo().Assembly);
 
             var broker = Broker.New(_ =>

--- a/src/Carrot.Benchmarks/Carrot.Benchmarks.csproj
+++ b/src/Carrot.Benchmarks/Carrot.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.NLog/Carrot.NLog.csproj
+++ b/src/Carrot.NLog/Carrot.NLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>a facility which enables NLog capabilities.</Description>
     <Title>Carrot.NLog</Title>
     <PackageId>Carrot.NLog</PackageId>

--- a/src/Carrot.RpcSample/Carrot.RpcSample.csproj
+++ b/src/Carrot.RpcSample/Carrot.RpcSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.Tests/ApplyingFallbackStrategy.cs
+++ b/src/Carrot.Tests/ApplyingFallbackStrategy.cs
@@ -5,8 +5,8 @@ using Carrot.Configuration;
 using Carrot.Fallback;
 using Carrot.Messages;
 using Moq;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -115,13 +115,17 @@ namespace Carrot.Tests
 
         private static BasicDeliverEventArgs FakeBasicDeliverEventArgs()
         {
-            return new BasicDeliverEventArgs
-                       {
-                           BasicProperties = new BasicProperties
-                                                 {
-                                                     Headers = new Dictionary<String, Object>()
-                                                 }
-                       };
+            var cf = new ConnectionFactory { DispatchConsumersAsync = true };
+            using (var c = cf.CreateConnection())
+            using (IModel m = c.CreateModel())
+            {
+                IBasicProperties bp = m.CreateBasicProperties();
+                bp.Headers = new Dictionary<String, Object>();
+                return new BasicDeliverEventArgs
+                {
+                    BasicProperties = bp
+                };
+            }
         }
 
         internal class AtLeastOnceConsumerWrapper : AtLeastOnceConsumer

--- a/src/Carrot.Tests/AtLeastOnceReplying.cs
+++ b/src/Carrot.Tests/AtLeastOnceReplying.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Carrot.Configuration;
 using Carrot.Messages;
 using Moq;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
 using Xunit;
@@ -87,7 +88,7 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
             {
                 DeliveryTag = 1234L,
-                BasicProperties = new BasicProperties()
+                BasicProperties = BasicPropertiesStubber.Stub()
             };
 
             var realConsumer = new Mock<Consumer<FakeConsumedMessage>>();
@@ -113,7 +114,7 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
                            {
                                DeliveryTag = deliveryTag,
-                               BasicProperties = new BasicProperties()
+                               BasicProperties = BasicPropertiesStubber.Stub()
                            };
             var builder = new Mock<IConsumedMessageBuilder>();
             var message = new FakeConsumedMessage(args, func);

--- a/src/Carrot.Tests/AtMostOnceReplying.cs
+++ b/src/Carrot.Tests/AtMostOnceReplying.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Carrot.Configuration;
 using Carrot.Messages;
 using Moq;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
 using Xunit;
@@ -33,7 +34,7 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
                            {
                                DeliveryTag = deliveryTag,
-                               BasicProperties = new BasicProperties()
+                               BasicProperties = BasicPropertiesStubber.Stub()
                            };
             Assert.Throws<Exception>(() => consumer.CallConsumeInternal(args).Wait());
             builder.Verify(_ => _.Build(args), Times.Never);

--- a/src/Carrot.Tests/BasicPropertiesStubber.cs
+++ b/src/Carrot.Tests/BasicPropertiesStubber.cs
@@ -1,0 +1,16 @@
+using RabbitMQ.Client;
+
+namespace Carrot.Tests
+{
+    public static class BasicPropertiesStubber
+    {
+        public static IBasicProperties Stub()
+        {
+            using (var c = new ConnectionFactory().CreateConnection())
+            using (IModel m = c.CreateModel())
+            {
+                return m.CreateBasicProperties();
+            }
+        }
+    }
+}

--- a/src/Carrot.Tests/Carrot.Tests.csproj
+++ b/src/Carrot.Tests/Carrot.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.7.137" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />

--- a/src/Carrot.Tests/ConsumingMessages.cs
+++ b/src/Carrot.Tests/ConsumingMessages.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Carrot.Configuration;
 using Carrot.Messages;
 using Moq;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
 using Xunit;
@@ -54,7 +55,7 @@ namespace Carrot.Tests
                                              new BasicDeliverEventArgs
                                                  {
                                                      Redelivered = true,
-                                                     BasicProperties = new BasicProperties()
+                                                     BasicProperties = BasicPropertiesStubber.Stub()
                                                  }).ConsumeAsync(new[] { consumer },
                                                                  outboundChannel)
                                                    .Result;
@@ -102,7 +103,7 @@ namespace Carrot.Tests
         {
             return new BasicDeliverEventArgs
                        {
-                           BasicProperties = new BasicProperties()
+                           BasicProperties = BasicPropertiesStubber.Stub()
                        };
         }
     }

--- a/src/Carrot.Tests/ContentNegotiating.cs
+++ b/src/Carrot.Tests/ContentNegotiating.cs
@@ -82,7 +82,7 @@ namespace Carrot.Tests
 
         internal class FakeSerializer : ISerializer
         {
-            public Object Deserialize(Byte[] body,
+            public Object Deserialize(ReadOnlyMemory<Byte> body,
                                       TypeInfo type,
                                       Encoding encoding = null)
             {

--- a/src/Carrot.Tests/MessageBuilding.cs
+++ b/src/Carrot.Tests/MessageBuilding.cs
@@ -37,17 +37,17 @@ namespace Carrot.Tests
             const String replyRoutingKey = "routing-key";
             const String correlationId = "one-correlation-id";
             var replyTo = $"{replyExchangeType}://{replyExchangeName}/{replyRoutingKey}";
+            
+            var properties = BasicPropertiesStubber.Stub();
+            properties.MessageId = messageId;
+            properties.Timestamp = new AmqpTimestamp(timestamp);
+            properties.CorrelationId = correlationId;
+            properties.ReplyTo = replyTo;
 
             var args = new BasicDeliverEventArgs
-                           {
-                               BasicProperties = new BasicProperties
-                                                     {
-                                                         MessageId = messageId,
-                                                         Timestamp = new AmqpTimestamp(timestamp),
-                                                         CorrelationId = correlationId,
-                                                         ReplyTo = replyTo
-                                                     }
-                           };
+            {
+                BasicProperties = properties
+            };
             var message = new FakeConsumedMessage(content, args);
             var actual = message.To<Foo>();
             Assert.Equal(messageId, actual.Headers.MessageId);
@@ -64,7 +64,7 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
                            {
                                ConsumerTag = consumerTag,
-                               BasicProperties = new BasicProperties()
+                               BasicProperties = BasicPropertiesStubber.Stub()
                            };
             var message = new FakeConsumedMessage(content, args);
             var actual = message.To<Foo>();
@@ -77,15 +77,14 @@ namespace Carrot.Tests
             var key = "a";
             var value = "b";
             var content = new Foo();
+            var properties = BasicPropertiesStubber.Stub();
+            properties.Headers = new Dictionary<String, Object>
+            {
+                {key, value}
+            };
             var args = new BasicDeliverEventArgs
                            {
-                               BasicProperties = new BasicProperties
-                                                     {
-                                                         Headers = new Dictionary<String, Object>
-                                                                       {
-                                                                           { key, value }
-                                                                       }
-                                                     }
+                               BasicProperties = properties
                            };
             var message = new FakeConsumedMessage(content, args);
 
@@ -99,7 +98,7 @@ namespace Carrot.Tests
         {
             return new BasicDeliverEventArgs
             {
-                BasicProperties = new BasicProperties()
+                BasicProperties = BasicPropertiesStubber.Stub()
             };
         }
     }

--- a/src/Carrot.Tests/MessageHeaders.cs
+++ b/src/Carrot.Tests/MessageHeaders.cs
@@ -52,7 +52,7 @@ namespace Carrot.Tests
             var resolver = new Mock<IMessageTypeResolver>();
             resolver.Setup(_ => _.Resolve<Foo>()).Returns(EmptyMessageBinding.Instance);
             var message = new OutboundMessage<Foo>(new Foo(), collection);
-            var properties = message.BuildBasicProperties(resolver.Object, null, null);
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), resolver.Object, null, null);
 
             Assert.Equal(messageId, properties.MessageId);
             Assert.Equal(new AmqpTimestamp(timestamp), properties.Timestamp);
@@ -85,7 +85,7 @@ namespace Carrot.Tests
             var dateTimeProvider = new Mock<IDateTimeProvider>();
             dateTimeProvider.Setup(_ => _.UtcNow()).Returns(timestamp.ToDateTimeOffset());
             var message = new OutboundMessage<Foo>(new Foo(), collection);
-            var properties = message.BuildBasicProperties(resolver.Object, dateTimeProvider.Object, newId.Object);
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), resolver.Object, dateTimeProvider.Object, newId.Object);
 
             Assert.Equal(messageId, properties.MessageId);
             Assert.Equal(new AmqpTimestamp(timestamp), properties.Timestamp);
@@ -136,14 +136,12 @@ namespace Carrot.Tests
             const String contentType = "application/json";
             const String correlationId = "some-id";
             const String messageId = "some-message-id";
-            var properties = new BasicProperties
-                                 {
-                                     Type = messageType,
-                                     ContentEncoding = contentEncoding,
-                                     ContentType = contentType,
-                                     CorrelationId = correlationId,
-                                     MessageId = messageId
-                                 };
+            var properties = BasicPropertiesStubber.Stub();
+            properties.Type = messageType;
+            properties.ContentEncoding = contentEncoding;
+            properties.ContentType = contentType;
+            properties.CorrelationId = correlationId;
+            properties.MessageId = messageId;
             var headers = HeaderCollection.Parse(properties);
             Assert.Equal(messageType, headers.Type);
             Assert.Equal(contentEncoding, headers.ContentEncoding);

--- a/src/Carrot.Tests/MessageProperties.cs
+++ b/src/Carrot.Tests/MessageProperties.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Carrot.Configuration;
 using Carrot.Extensions;
-using RabbitMQ.Client.Framing;
+using Moq;
 using Xunit;
 
 namespace Carrot.Tests
@@ -16,10 +16,9 @@ namespace Carrot.Tests
         public void ReadingRabbitContentType()
         {
             const String contentType = "application/custom";
-            var properties = new BasicProperties
-                                 {
-                                     ContentType = contentType
-                                 };
+            var model = new Mock<IModel>();
+            var properties = BasicPropertiesStubber.Stub();
+            properties.ContentType = contentType;
             Assert.Equal(contentType, properties.ContentTypeOrDefault());
         }
 
@@ -29,21 +28,19 @@ namespace Carrot.Tests
             const String contentType = "application/custom";
             const String contentEncoding = "UTF-8";
             var encoding = Encoding.GetEncoding(contentEncoding);
-            var properties = new BasicProperties
-                                 {
-                                     ContentEncoding = contentEncoding,
-                                     Headers = new Dictionary<String, Object>
-                                                   {
-                                                       { "Content-Type", encoding.GetBytes(contentType) }
-                                                   }
-                                 };
+            var properties = BasicPropertiesStubber.Stub();
+            properties.ContentEncoding = contentEncoding;
+            properties.Headers = new Dictionary<String, Object>
+            {
+                {"Content-Type", encoding.GetBytes(contentType)}
+            };
             Assert.Equal(contentType, properties.ContentTypeOrDefault());
         }
 
         [Fact]
         public void DefaultContentType()
         {
-            var properties = new BasicProperties();
+            var properties = BasicPropertiesStubber.Stub();
             Assert.Equal(SerializationConfiguration.DefaultContentType,
                          properties.ContentTypeOrDefault());
         }
@@ -52,71 +49,18 @@ namespace Carrot.Tests
         public void ReadingRabbitContentEncoding()
         {
             const String contentEncoding = "UTF-16";
-            var properties = new BasicProperties
-                                 {
-                                     ContentEncoding = contentEncoding
-                                 };
+            var properties = BasicPropertiesStubber.Stub();
+            properties.ContentEncoding = contentEncoding;
+            
             Assert.Equal(contentEncoding, properties.ContentEncodingOrDefault());
         }
 
         [Fact]
         public void DefaultContentEncoding()
         {
-            var properties = new BasicProperties();
+            var properties = BasicPropertiesStubber.Stub();
             Assert.Equal(SerializationConfiguration.DefaultContentEncoding,
                          properties.ContentEncodingOrDefault());
-        }
-
-        [Fact]
-        public void Cloning()
-        {
-            var properties = new BasicProperties
-                                 {
-                                     Headers = new Dictionary<String, Object>
-                                                   {
-                                                       { "a", "b" }
-                                                   },
-                                     AppId = "some-app-id",
-                                     ClusterId = "2",
-                                     ContentEncoding = "utf-8",
-                                     ContentType = "application/json",
-                                     CorrelationId = "3",
-                                     DeliveryMode = 1,
-                                     Expiration = "22",
-                                     MessageId = "message-id",
-                                     Priority = 1,
-                                     ReplyTo = "",
-                                     Timestamp = new AmqpTimestamp(123456789L),
-                                     Type = "some-type",
-                                     UserId = "user-id"
-                                 };
-            Assert.Equal(properties,
-                         (BasicProperties)((IBasicProperties)properties).Clone(),
-                         new BasicPropertiesEqualityComparer());
-        }
-
-        internal class BasicPropertiesEqualityComparer : IEqualityComparer<BasicProperties>
-        {
-            public Boolean Equals(BasicProperties x, BasicProperties y)
-            {
-                if (x == null || y == null)
-                    return false;
-
-                var a = new StringBuilder();
-                x.AppendPropertyDebugStringTo(a);
-                var b = new StringBuilder();
-                y.AppendPropertyDebugStringTo(b);
-
-                return String.Equals(a.ToString(), b.ToString());
-            }
-
-            public Int32 GetHashCode(BasicProperties obj)
-            {
-                var a = new StringBuilder();
-                obj.AppendPropertyDebugStringTo(a);
-
-                return a.GetHashCode();
-            }
         }
     }
 }

--- a/src/Carrot.Tests/MessageResolving.cs
+++ b/src/Carrot.Tests/MessageResolving.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using Carrot.Configuration;
 using Carrot.Messages;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
 using Xunit;
@@ -13,21 +14,25 @@ namespace Carrot.Tests
         [Fact]
         public void Resolve()
         {
-            const String source = "urn:message:foo";
-            var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = source } };
+            const String typeName = "urn:message:foo";
+            var properties = BasicPropertiesStubber.Stub();
+            properties.Type = typeName;
+            var args = new BasicDeliverEventArgs { BasicProperties = properties };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var type = typeof(Foo);
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
             var binding = resolver.Resolve(context);
-            Assert.Equal(source, binding.RawName);
+            Assert.Equal(typeName, binding.RawName);
             Assert.Equal(type, binding.RuntimeType);
         }
 
         [Fact]
         public void CannotResolve()
         {
-            const String source = "urn:message:no-resolve";
-            var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = source } };
+            const String typeName = "urn:message:no-resolve";
+            var properties = BasicPropertiesStubber.Stub();
+            properties.Type = typeName;
+            var args = new BasicDeliverEventArgs { BasicProperties = properties };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var type = typeof(Foo);
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
@@ -67,7 +72,9 @@ namespace Carrot.Tests
         public void Default()
         {
             const String typeName = "Carrot.Tests.Foo";
-            var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = typeName } };
+            var properties = BasicPropertiesStubber.Stub();
+            properties.Type = typeName;
+            var args = new BasicDeliverEventArgs { BasicProperties = properties };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var resolver = new DefaultMessageTypeResolver(typeof(Foo).Assembly);
             var binding = resolver.Resolve(context);

--- a/src/Carrot.Tests/OutboundEnveloping.cs
+++ b/src/Carrot.Tests/OutboundEnveloping.cs
@@ -22,6 +22,7 @@ namespace Carrot.Tests
             const UInt64 deliveryTag = 0uL;
             var model = new Mock<IModel>();
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub);
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
             resolver.Setup(_ => _.Resolve<Foo>())
@@ -48,6 +49,7 @@ namespace Carrot.Tests
             const UInt64 deliveryTag = 0uL;
             var model = new Mock<IModel>();
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub);
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
             resolver.Setup(_ => _.Resolve<Foo>())
@@ -74,11 +76,12 @@ namespace Carrot.Tests
             var message = NewMessage();
             var exception = new Exception();
             var model = new Mock<IModel>();
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub);
             model.Setup(_ => _.BasicPublish(exchange,
                                             String.Empty,
                                             false,
                                             It.IsAny<IBasicProperties>(),
-                                            It.IsAny<Byte[]>()))
+                                            It.IsAny<ReadOnlyMemory<Byte>>()))
                  .Throws(exception);
 
             var configuration = new EnvironmentConfiguration();
@@ -104,6 +107,7 @@ namespace Carrot.Tests
             const UInt64 deliveryTag = 0uL;
             var model = new Mock<IModel>();
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub);
             var fallbackHandled = false;
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
@@ -142,7 +146,8 @@ namespace Carrot.Tests
                     .Returns(new MessageBinding("urn:message:fake",
                                                 typeof(Foo).GetTypeInfo()));
 
-            var properties = message.BuildBasicProperties(resolver.Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          resolver.Object,
                                                           dateTimeProvider.Object,
                                                           newId.Object);
             Assert.Equal(messageId, properties.MessageId);
@@ -153,7 +158,8 @@ namespace Carrot.Tests
         public void MessageType()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("urn:message:fake", properties.Type);
@@ -165,7 +171,8 @@ namespace Carrot.Tests
             const String contentEncoding = "UTF-16";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetContentEncoding(contentEncoding);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(contentEncoding, properties.ContentEncoding);
@@ -175,7 +182,8 @@ namespace Carrot.Tests
         public void DefaultContentEncoding()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("UTF-8", properties.ContentEncoding);
@@ -187,7 +195,8 @@ namespace Carrot.Tests
             const String contentType = "application/xml";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetContentType(contentType);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(contentType, properties.ContentType);
@@ -197,7 +206,8 @@ namespace Carrot.Tests
         public void DefaultContentType()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("application/json", properties.ContentType);
@@ -209,7 +219,8 @@ namespace Carrot.Tests
             String correlationId = Guid.NewGuid().ToString();
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetCorrelationId(correlationId);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(correlationId, properties.CorrelationId);
@@ -222,7 +233,8 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new DirectReplyConfiguration(replyExchangeName, replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("direct", properties.ReplyToAddress.ExchangeType);
@@ -237,7 +249,8 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new DirectReplyConfiguration(replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("direct:///replyRoutingKey", properties.ReplyTo);
@@ -250,7 +263,8 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new TopicReplyConfiguration(replyExchangeName, replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("topic", properties.ReplyToAddress.ExchangeType);
@@ -265,7 +279,8 @@ namespace Carrot.Tests
             const String replyExchangeName = "replyExchangeName";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new FanoutReplyConfiguration(replyExchangeName));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("fanout", properties.ReplyToAddress.ExchangeType);
@@ -278,7 +293,8 @@ namespace Carrot.Tests
         public void NonDurableMessage()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.False(properties.Persistent);
@@ -288,7 +304,8 @@ namespace Carrot.Tests
         public void DurableMessage()
         {
             var message = new DurableOutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.True(properties.Persistent);
@@ -299,7 +316,8 @@ namespace Carrot.Tests
         {
             var expiresAfter = new TimeSpan?(TimeSpan.FromSeconds(18));
             var message = new DurableOutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(expiresAfter).Object,
+            var properties = message.BuildBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(expiresAfter).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("18000", properties.Expiration);

--- a/src/Carrot.Tests/SubscribingConfiguration.cs
+++ b/src/Carrot.Tests/SubscribingConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Carrot.Configuration;
 using Moq;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
 using Xunit;
@@ -50,12 +51,11 @@ namespace Carrot.Tests
 
         private static BasicDeliverEventArgs FakeBasicDeliverEventArgs()
         {
+            var properties = BasicPropertiesStubber.Stub();
+            properties.Headers = new Dictionary<String, Object>();
             return new BasicDeliverEventArgs
                        {
-                           BasicProperties = new BasicProperties
-                                                 {
-                                                     Headers = new Dictionary<String, Object>()
-                                                 }
+                           BasicProperties = properties
                        };
         }
     }

--- a/src/Carrot.log4net/Carrot.log4net.csproj
+++ b/src/Carrot.log4net/Carrot.log4net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>a facility which enables log4net capabilities.</Description>
     <Title>Carrot.log4net</Title>
     <PackageId>Carrot.log4net</PackageId>

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Carrot is a .NET lightweight library that provides a couple of facilities over RabbitMQ.</Description>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet</PackageTargetFallback>
     <Title>Carrot</Title>
@@ -18,12 +18,8 @@
     </PackageReleaseNotes>
     <PackageLicenseUrl>https://raw.githubusercontent.com/naighes/Carrot/master/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.5'">
-    <PackageReference Include="System.AppDomain" Version="2.0.11" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -7,16 +7,17 @@
     <PackageId>Carrot</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <AssemblyVersion>1.1.1</AssemblyVersion>
-    <FileVersion>1.1.1</FileVersion>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
+    <FileVersion>1.2.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>copyright © Nicola Baldi (naighes) 2019</Copyright>
     <RepositoryUrl>https://github.com/naighes/Carrot.git</RepositoryUrl>
     <PackageTags>rabbitmq</PackageTags>
     <PackageReleaseNotes>
-      PublishAsync now supports exchange parameter as String.
-    </PackageReleaseNotes>
+      Updated rabbimq driver to major version 6 
+</PackageReleaseNotes>
     <PackageLicenseUrl>https://raw.githubusercontent.com/naighes/Carrot/master/LICENSE.txt</PackageLicenseUrl>
+    <Version>1.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/Carrot/ConsumerBase.cs
+++ b/src/Carrot/ConsumerBase.cs
@@ -37,7 +37,7 @@ namespace Carrot
                                                 String exchange,
                                                 String routingKey,
                                                 IBasicProperties properties,
-                                                Byte[] body)
+                                                ReadOnlyMemory<Byte> body)
         {
             base.HandleBasicDeliver(consumerTag,
                                     deliveryTag,

--- a/src/Carrot/Extensions/BasicPropertiesExtensions.cs
+++ b/src/Carrot/Extensions/BasicPropertiesExtensions.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Linq;
 using System.Text;
 using Carrot.Configuration;
 using Carrot.Serialization;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Framing;
 
 namespace Carrot.Extensions
 {
@@ -44,27 +42,6 @@ namespace Carrot.Extensions
                                                         String @default = "UTF-8")
         {
             return source.ContentEncoding ?? @default;
-        }
-
-        internal static IBasicProperties Clone(this IBasicProperties source)
-        {
-            return new BasicProperties
-                       {
-                           AppId = source.AppId,
-                           ClusterId = source.ClusterId,
-                           ContentEncoding = source.ContentEncoding,
-                           ContentType = source.ContentType,
-                           CorrelationId = source.CorrelationId,
-                           DeliveryMode = source.DeliveryMode,
-                           Expiration = source.Expiration,
-                           MessageId = source.MessageId,
-                           Priority = source.Priority,
-                           ReplyTo = source.ReplyTo,
-                           Timestamp = source.Timestamp,
-                           Type = source.Type,
-                           UserId = source.UserId,
-                           Headers = source.Headers.ToDictionary(_ => _.Key, _ => _.Value)
-                       };
         }
     }
 }

--- a/src/Carrot/LoggedAtLeastOnceConsumer.cs
+++ b/src/Carrot/LoggedAtLeastOnceConsumer.cs
@@ -45,7 +45,7 @@ namespace Carrot
         {
             base.OnConsumerCancelled(sender, args);
 
-            _log.Info($"consumer-model basic.cancel received (consumer-tag: '{args.ConsumerTag}')");
+            _log.Info($"consumer-model basic.cancel received (consumer-tags: '{String.Join(",",args.ConsumerTags)}')");
         }
     }
 }

--- a/src/Carrot/LoggedAtMostOnceConsumer.cs
+++ b/src/Carrot/LoggedAtMostOnceConsumer.cs
@@ -45,7 +45,7 @@ namespace Carrot
         {
             base.OnConsumerCancelled(sender, args);
 
-            _log.Info($"consumer-model basic.cancel received (consumer-tag: '{args.ConsumerTag}')");
+            _log.Info($"consumer-model basic.cancel received (consumer-tags: '{String.Join(",", args.ConsumerTags)}')");
         }
     }
 }

--- a/src/Carrot/Messages/DurableOutboundMessage.cs
+++ b/src/Carrot/Messages/DurableOutboundMessage.cs
@@ -11,11 +11,12 @@ namespace Carrot.Messages
         {
         }
 
-        internal override IBasicProperties BuildBasicProperties(IMessageTypeResolver resolver,
+        internal override IBasicProperties BuildBasicProperties(IBasicProperties basicProperties,
+                                                                IMessageTypeResolver resolver,
                                                                 IDateTimeProvider dateTimeProvider,
                                                                 INewId idGenerator)
         {
-            var properties = base.BuildBasicProperties(resolver, dateTimeProvider, idGenerator);
+            var properties = base.BuildBasicProperties(basicProperties, resolver, dateTimeProvider, idGenerator);
             properties.Persistent = true;
             return properties;
         }

--- a/src/Carrot/OutboundChannel.cs
+++ b/src/Carrot/OutboundChannel.cs
@@ -124,7 +124,7 @@ namespace Carrot
             }
             catch (Exception exception) { tcs.TrySetException(exception); }
 
-            return tcs.Task.ContinueWith(Result);
+            return tcs.Task.ContinueWith(Result, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
     }
 }

--- a/src/Carrot/ReliableOutboundChannel.cs
+++ b/src/Carrot/ReliableOutboundChannel.cs
@@ -41,7 +41,7 @@ namespace Carrot
         {
             var properties = BuildBasicProperties(source);
             var body = BuildBody(source, properties);
-            var tcs = new TaskCompletionSource<Boolean>(properties);
+            var tcs = new TaskCompletionSource<Boolean>(properties, TaskCreationOptions.RunContinuationsAsynchronously);
             var tag = Model.NextPublishSeqNo;
             _confirms.TryAdd(tag, new Tuple<TaskCompletionSource<Boolean>, IMessage>(tcs, source));
 
@@ -60,7 +60,7 @@ namespace Carrot
                 tcs.TrySetException(exception);
             }
 
-            return tcs.Task.ContinueWith(Result);
+            return tcs.Task.ContinueWith(Result, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         protected override void OnModelDisposing()

--- a/src/Carrot/Serialization/ISerializer.cs
+++ b/src/Carrot/Serialization/ISerializer.cs
@@ -6,7 +6,7 @@ namespace Carrot.Serialization
 {
     public interface ISerializer
     {
-        Object Deserialize(Byte[] body, TypeInfo type, Encoding encoding = null);
+        Object Deserialize(ReadOnlyMemory<Byte> body, TypeInfo type, Encoding encoding = null);
 
         String Serialize(Object obj);
     }

--- a/src/Carrot/Serialization/JsonSerializer.cs
+++ b/src/Carrot/Serialization/JsonSerializer.cs
@@ -9,10 +9,10 @@ namespace Carrot.Serialization
     {
         public JsonSerializerSettings Settings { get; } = new JsonSerializerSettings();
 
-        public Object Deserialize(Byte[] body, TypeInfo type, Encoding encoding = null)
+        public object Deserialize(ReadOnlyMemory<Byte> body, TypeInfo type, Encoding encoding = null)
         {
             var e = encoding ?? new UTF8Encoding(true);
-            return JsonConvert.DeserializeObject(e.GetString(body),
+            return JsonConvert.DeserializeObject(e.GetString(body.Span.ToArray()),
                                                  type.AsType(),
                                                  Settings);
         }

--- a/src/Carrot/Serialization/NullSerializer.cs
+++ b/src/Carrot/Serialization/NullSerializer.cs
@@ -10,9 +10,9 @@ namespace Carrot.Serialization
 
         private NullSerializer() { }
 
-        public Object Deserialize(Byte[] body,
-                                  TypeInfo type,
-                                  Encoding encoding = null)
+        public object Deserialize(ReadOnlyMemory<Byte> body,
+            TypeInfo type,
+            Encoding encoding = null)
         {
             return null;
         }


### PR DESCRIPTION
RabbitMQ dotnet driver update - some breaking changes were introduced with major release 6, as reported in [changelog](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/master/CHANGELOG.md#changes-between-520-and-600).
As a result minimum supported versions are now net461/netframework2.0.
Version bumped to 1.2.0 ( Carrot package only )

Notes:
BasicProperties class visibility changed - this caused so many changes to internals.