### PR TITLE
Rabbitmq6

### DIFF
--- a/src/Carrot.BasicSample/Carrot.BasicSample.csproj
+++ b/src/Carrot.BasicSample/Carrot.BasicSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.BasicSample/Program.cs
+++ b/src/Carrot.BasicSample/Program.cs
@@ -11,7 +11,7 @@ namespace Carrot.BasicSample
         private static void Main()
         {
             const String routingKey = "routing_key";
-            const String endpointUrl = "amqp://guest:guest@localhost:5674/";
+            const String endpointUrl = "amqp://guest:guest@localhost:5672/";
             IMessageTypeResolver resolver = new MessageBindingResolver(typeof(Foo).GetTypeInfo().Assembly);
 
             var broker = Broker.New(_ =>

--- a/src/Carrot.Benchmarks/Carrot.Benchmarks.csproj
+++ b/src/Carrot.Benchmarks/Carrot.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.Benchmarks/Jobs/ConsumingJob.cs
+++ b/src/Carrot.Benchmarks/Jobs/ConsumingJob.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Carrot.Messages;
 
 namespace Carrot.Benchmarks.Jobs
 {

--- a/src/Carrot.Benchmarks/Jobs/PublishJob.cs
+++ b/src/Carrot.Benchmarks/Jobs/PublishJob.cs
@@ -44,7 +44,7 @@ namespace Carrot.Benchmarks.Jobs
                                          _stopwatch.Reset();
                                          connection.Dispose();
                                          return JobResult.New(elapsed, this, count);
-                                     });
+                                     }, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         protected abstract OutboundMessage<Foo> BuildMessage(Int32 i);

--- a/src/Carrot.NLog/Carrot.NLog.csproj
+++ b/src/Carrot.NLog/Carrot.NLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>a facility which enables NLog capabilities.</Description>
     <Title>Carrot.NLog</Title>
     <PackageId>Carrot.NLog</PackageId>

--- a/src/Carrot.RpcSample/Carrot.RpcSample.csproj
+++ b/src/Carrot.RpcSample/Carrot.RpcSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.Tests/ApplyingFallbackStrategy.cs
+++ b/src/Carrot.Tests/ApplyingFallbackStrategy.cs
@@ -6,7 +6,6 @@ using Carrot.Fallback;
 using Carrot.Messages;
 using Moq;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -51,7 +50,7 @@ namespace Carrot.Tests
             var args = FakeBasicDeliverEventArgs();
             var message = new FakeConsumedMessage(new Object(), args);
             _configuration.FallbackBy((c, q) => strategy.Object);
-            _configuration.Consumes(new FakeConsumer(consumedMessage => { throw new Exception(); }));
+            _configuration.Consumes(new FakeConsumer(consumedMessage => throw new Exception()));
             var builder = new Mock<IConsumedMessageBuilder>();
             builder.Setup(_ => _.Build(args)).Returns(message);
             var outboundChannel = new Mock<IOutboundChannel>().Object;
@@ -116,15 +115,12 @@ namespace Carrot.Tests
         private static BasicDeliverEventArgs FakeBasicDeliverEventArgs()
         {
             return new BasicDeliverEventArgs
-                       {
-                           BasicProperties = new BasicProperties
-                                                 {
-                                                     Headers = new Dictionary<String, Object>()
-                                                 }
-                       };
+            {
+                BasicProperties = BasicPropertiesStubber.Stub(_ => _.Headers = new Dictionary<String, Object>())
+            };
         }
 
-        internal class AtLeastOnceConsumerWrapper : AtLeastOnceConsumer
+        private class AtLeastOnceConsumerWrapper : AtLeastOnceConsumer
         {
             public AtLeastOnceConsumerWrapper(IInboundChannel inboundChannel,
                                               IOutboundChannel outboundChannel,

--- a/src/Carrot.Tests/AtLeastOnceReplying.cs
+++ b/src/Carrot.Tests/AtLeastOnceReplying.cs
@@ -5,7 +5,6 @@ using Carrot.Configuration;
 using Carrot.Messages;
 using Moq;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -87,7 +86,7 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
             {
                 DeliveryTag = 1234L,
-                BasicProperties = new BasicProperties()
+                BasicProperties = BasicPropertiesStubber.Stub()
             };
 
             var realConsumer = new Mock<Consumer<FakeConsumedMessage>>();
@@ -113,7 +112,7 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
                            {
                                DeliveryTag = deliveryTag,
-                               BasicProperties = new BasicProperties()
+                               BasicProperties = BasicPropertiesStubber.Stub()
                            };
             var builder = new Mock<IConsumedMessageBuilder>();
             var message = new FakeConsumedMessage(args, func);
@@ -139,10 +138,7 @@ namespace Carrot.Tests
                 _result = result;
             }
 
-            internal override Object Content
-            {
-                get { throw new NotImplementedException(); }
-            }
+            internal override Object Content => throw new NotImplementedException();
 
             internal override Task<AggregateConsumingResult> ConsumeAsync(IEnumerable<IConsumer> subscriptions,
                                                                           IOutboundChannel outboundChannel)

--- a/src/Carrot.Tests/AtMostOnceReplying.cs
+++ b/src/Carrot.Tests/AtMostOnceReplying.cs
@@ -4,7 +4,6 @@ using Carrot.Configuration;
 using Carrot.Messages;
 using Moq;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -33,13 +32,13 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
                            {
                                DeliveryTag = deliveryTag,
-                               BasicProperties = new BasicProperties()
+                               BasicProperties = BasicPropertiesStubber.Stub()
                            };
             Assert.Throws<Exception>(() => consumer.CallConsumeInternal(args).Wait());
             builder.Verify(_ => _.Build(args), Times.Never);
         }
 
-        internal class AtMostOnceConsumerWrapper : AtMostOnceConsumer
+        private class AtMostOnceConsumerWrapper : AtMostOnceConsumer
         {
             internal AtMostOnceConsumerWrapper(IInboundChannel inboundChannel,
                                                IOutboundChannel outboundChannel,

--- a/src/Carrot.Tests/BasicPropertiesStubber.cs
+++ b/src/Carrot.Tests/BasicPropertiesStubber.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using RabbitMQ.Client;
+
+namespace Carrot.Tests
+{
+    public static class BasicPropertiesStubber
+    {
+        public static IBasicProperties Stub(Action<IBasicProperties> configure = default)
+        {
+            var basicProperties = InstantiateViaReflection();
+            configure?.Invoke(basicProperties);
+            return basicProperties;
+        }
+
+        private static IBasicProperties InstantiateViaReflection()
+        {
+            var assembly = Assembly.Load("RabbitMQ.Client");
+            var ctor = assembly
+                .GetType("RabbitMQ.Client.Framing.BasicProperties")
+                .GetConstructors().Single();
+            return (IBasicProperties) ctor.Invoke(new object[0]);
+        }
+    }
+    
+}

--- a/src/Carrot.Tests/Carrot.Tests.csproj
+++ b/src/Carrot.Tests/Carrot.Tests.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
-  </PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+</PropertyGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.7.137" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />

--- a/src/Carrot.Tests/Connecting.cs
+++ b/src/Carrot.Tests/Connecting.cs
@@ -55,7 +55,7 @@ namespace Carrot.Tests
             return connectionBuilder;
         }
 
-        internal class BrokerWrapper : Broker
+        private class BrokerWrapper : Broker
         {
             private readonly IModel _model;
 

--- a/src/Carrot.Tests/ConnectionBuilding.cs
+++ b/src/Carrot.Tests/ConnectionBuilding.cs
@@ -19,7 +19,7 @@ namespace Carrot.Tests
             Assert.Equal("Carrot", factory.ClientProperties["client_api"].ToString());
         }
 
-        internal class ConnectionBuilderWrapper : ConnectionBuilder
+        private class ConnectionBuilderWrapper : ConnectionBuilder
         {
             public ConnectionBuilderWrapper(IDateTimeProvider dateTimeProvider)
                 : base(dateTimeProvider)

--- a/src/Carrot.Tests/ConsumedMessageBuilding.cs
+++ b/src/Carrot.Tests/ConsumedMessageBuilding.cs
@@ -6,7 +6,6 @@ using Carrot.Messages;
 using Carrot.Serialization;
 using Moq;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -23,9 +22,9 @@ namespace Carrot.Tests
                     .Returns(EmptyMessageBinding.Instance);
             var builder = new ConsumedMessageBuilder(serializationConfiguration, resolver.Object);
             var message = builder.Build(new BasicDeliverEventArgs
-                                            {
-                                                BasicProperties = new BasicProperties { Type = type }
-                                            });
+            {
+                BasicProperties = BasicPropertiesStubber.Stub(_ => _.Type = type)
+            });
             Assert.IsType<UnresolvedMessage>(message);
         }
 
@@ -40,7 +39,7 @@ namespace Carrot.Tests
             var builder = new ConsumedMessageBuilder(serializationConfiguration, resolver.Object);
             var message = builder.Build(new BasicDeliverEventArgs
                                             {
-                                                BasicProperties = new BasicProperties { Type = type }
+                                                BasicProperties = BasicPropertiesStubber.Stub(_ => _.Type = type)
                                             });
             Assert.IsType<UnresolvedMessage>(message);
         }
@@ -54,7 +53,7 @@ namespace Carrot.Tests
             var builder = new ConsumedMessageBuilder(serializationConfiguration, resolver.Object);
             var message = builder.Build(new BasicDeliverEventArgs
                                             {
-                                                BasicProperties = new BasicProperties { ContentType = contentType }
+                                                BasicProperties = BasicPropertiesStubber.Stub(_ => _.ContentType = contentType)
                                             });
             Assert.IsType<UnsupportedMessage>(message);
         }
@@ -68,11 +67,11 @@ namespace Carrot.Tests
             var args = new BasicDeliverEventArgs
                            {
                                Body = body,
-                               BasicProperties = new BasicProperties
+                               BasicProperties = BasicPropertiesStubber.Stub(_ =>
                                {
-                                   ContentType = contentType,
-                                   Type = type
-                               }
+                                   _.ContentType = contentType;
+                                   _.Type = type;
+                               })
                            };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var runtimeType = typeof(Foo).GetTypeInfo();
@@ -87,7 +86,7 @@ namespace Carrot.Tests
             Assert.IsType<CorruptedMessage>(message);
         }
 
-        internal class SerializationConfigurationWrapper : SerializationConfiguration
+        private class SerializationConfigurationWrapper : SerializationConfiguration
         {
             private readonly ISerializer _serializer;
 

--- a/src/Carrot.Tests/ConsumingMessages.cs
+++ b/src/Carrot.Tests/ConsumingMessages.cs
@@ -6,7 +6,6 @@ using Carrot.Configuration;
 using Carrot.Messages;
 using Moq;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -54,7 +53,7 @@ namespace Carrot.Tests
                                              new BasicDeliverEventArgs
                                                  {
                                                      Redelivered = true,
-                                                     BasicProperties = new BasicProperties()
+                                                     BasicProperties = BasicPropertiesStubber.Stub()
                                                  }).ConsumeAsync(new[] { consumer },
                                                                  outboundChannel)
                                                    .Result;
@@ -102,7 +101,7 @@ namespace Carrot.Tests
         {
             return new BasicDeliverEventArgs
                        {
-                           BasicProperties = new BasicProperties()
+                           BasicProperties = BasicPropertiesStubber.Stub()
                        };
         }
     }

--- a/src/Carrot.Tests/ContentNegotiating.cs
+++ b/src/Carrot.Tests/ContentNegotiating.cs
@@ -82,7 +82,7 @@ namespace Carrot.Tests
 
         internal class FakeSerializer : ISerializer
         {
-            public Object Deserialize(Byte[] body,
+            public Object Deserialize(ReadOnlyMemory<Byte> body,
                                       TypeInfo type,
                                       Encoding encoding = null)
             {

--- a/src/Carrot.Tests/MessageProperties.cs
+++ b/src/Carrot.Tests/MessageProperties.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Carrot.Configuration;
 using Carrot.Extensions;
-using RabbitMQ.Client.Framing;
+using Moq;
 using Xunit;
 
 namespace Carrot.Tests
@@ -16,10 +16,8 @@ namespace Carrot.Tests
         public void ReadingRabbitContentType()
         {
             const String contentType = "application/custom";
-            var properties = new BasicProperties
-                                 {
-                                     ContentType = contentType
-                                 };
+            var model = new Mock<IModel>();
+            var properties = BasicPropertiesStubber.Stub(_ => _.ContentType = contentType);
             Assert.Equal(contentType, properties.ContentTypeOrDefault());
         }
 
@@ -29,21 +27,21 @@ namespace Carrot.Tests
             const String contentType = "application/custom";
             const String contentEncoding = "UTF-8";
             var encoding = Encoding.GetEncoding(contentEncoding);
-            var properties = new BasicProperties
-                                 {
-                                     ContentEncoding = contentEncoding,
-                                     Headers = new Dictionary<String, Object>
-                                                   {
-                                                       { "Content-Type", encoding.GetBytes(contentType) }
-                                                   }
-                                 };
+            var properties = BasicPropertiesStubber.Stub(_ =>
+            {
+                _.ContentEncoding = contentEncoding;
+                _.Headers = new Dictionary<String, Object>
+                {
+                    {"Content-Type", encoding.GetBytes(contentType)}
+                };
+            });
             Assert.Equal(contentType, properties.ContentTypeOrDefault());
         }
 
         [Fact]
         public void DefaultContentType()
         {
-            var properties = new BasicProperties();
+            var properties = BasicPropertiesStubber.Stub();
             Assert.Equal(SerializationConfiguration.DefaultContentType,
                          properties.ContentTypeOrDefault());
         }
@@ -52,71 +50,17 @@ namespace Carrot.Tests
         public void ReadingRabbitContentEncoding()
         {
             const String contentEncoding = "UTF-16";
-            var properties = new BasicProperties
-                                 {
-                                     ContentEncoding = contentEncoding
-                                 };
+            var properties = BasicPropertiesStubber.Stub(_ => _.ContentEncoding = contentEncoding);
+
             Assert.Equal(contentEncoding, properties.ContentEncodingOrDefault());
         }
 
         [Fact]
         public void DefaultContentEncoding()
         {
-            var properties = new BasicProperties();
+            var properties = BasicPropertiesStubber.Stub();
             Assert.Equal(SerializationConfiguration.DefaultContentEncoding,
                          properties.ContentEncodingOrDefault());
-        }
-
-        [Fact]
-        public void Cloning()
-        {
-            var properties = new BasicProperties
-                                 {
-                                     Headers = new Dictionary<String, Object>
-                                                   {
-                                                       { "a", "b" }
-                                                   },
-                                     AppId = "some-app-id",
-                                     ClusterId = "2",
-                                     ContentEncoding = "utf-8",
-                                     ContentType = "application/json",
-                                     CorrelationId = "3",
-                                     DeliveryMode = 1,
-                                     Expiration = "22",
-                                     MessageId = "message-id",
-                                     Priority = 1,
-                                     ReplyTo = "",
-                                     Timestamp = new AmqpTimestamp(123456789L),
-                                     Type = "some-type",
-                                     UserId = "user-id"
-                                 };
-            Assert.Equal(properties,
-                         (BasicProperties)((IBasicProperties)properties).Clone(),
-                         new BasicPropertiesEqualityComparer());
-        }
-
-        internal class BasicPropertiesEqualityComparer : IEqualityComparer<BasicProperties>
-        {
-            public Boolean Equals(BasicProperties x, BasicProperties y)
-            {
-                if (x == null || y == null)
-                    return false;
-
-                var a = new StringBuilder();
-                x.AppendPropertyDebugStringTo(a);
-                var b = new StringBuilder();
-                y.AppendPropertyDebugStringTo(b);
-
-                return String.Equals(a.ToString(), b.ToString());
-            }
-
-            public Int32 GetHashCode(BasicProperties obj)
-            {
-                var a = new StringBuilder();
-                obj.AppendPropertyDebugStringTo(a);
-
-                return a.GetHashCode();
-            }
         }
     }
 }

--- a/src/Carrot.Tests/MessageResolving.cs
+++ b/src/Carrot.Tests/MessageResolving.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using Carrot.Configuration;
 using Carrot.Messages;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -13,21 +12,21 @@ namespace Carrot.Tests
         [Fact]
         public void Resolve()
         {
-            const String source = "urn:message:foo";
-            var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = source } };
+            const String typeName = "urn:message:foo";
+            var args = new BasicDeliverEventArgs { BasicProperties = BasicPropertiesStubber.Stub(_ => _.Type = typeName) };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var type = typeof(Foo);
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
             var binding = resolver.Resolve(context);
-            Assert.Equal(source, binding.RawName);
+            Assert.Equal(typeName, binding.RawName);
             Assert.Equal(type, binding.RuntimeType);
         }
 
         [Fact]
         public void CannotResolve()
         {
-            const String source = "urn:message:no-resolve";
-            var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = source } };
+            const String typeName = "urn:message:no-resolve";
+            var args = new BasicDeliverEventArgs { BasicProperties = BasicPropertiesStubber.Stub(_ => _.Type = typeName) };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var type = typeof(Foo);
             var resolver = new MessageBindingResolver(type.GetTypeInfo().Assembly);
@@ -67,7 +66,7 @@ namespace Carrot.Tests
         public void Default()
         {
             const String typeName = "Carrot.Tests.Foo";
-            var args = new BasicDeliverEventArgs { BasicProperties = new BasicProperties { Type = typeName } };
+            var args = new BasicDeliverEventArgs { BasicProperties = BasicPropertiesStubber.Stub(_ => _.Type = typeName) };
             var context = ConsumedMessageContext.FromBasicDeliverEventArgs(args);
             var resolver = new DefaultMessageTypeResolver(typeof(Foo).Assembly);
             var binding = resolver.Resolve(context);

--- a/src/Carrot.Tests/OutboundEnveloping.cs
+++ b/src/Carrot.Tests/OutboundEnveloping.cs
@@ -22,6 +22,7 @@ namespace Carrot.Tests
             const UInt64 deliveryTag = 0uL;
             var model = new Mock<IModel>();
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub());
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
             resolver.Setup(_ => _.Resolve<Foo>())
@@ -48,6 +49,7 @@ namespace Carrot.Tests
             const UInt64 deliveryTag = 0uL;
             var model = new Mock<IModel>();
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub());
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
             resolver.Setup(_ => _.Resolve<Foo>())
@@ -74,11 +76,12 @@ namespace Carrot.Tests
             var message = NewMessage();
             var exception = new Exception();
             var model = new Mock<IModel>();
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub());
             model.Setup(_ => _.BasicPublish(exchange,
                                             String.Empty,
                                             false,
                                             It.IsAny<IBasicProperties>(),
-                                            It.IsAny<Byte[]>()))
+                                            It.IsAny<ReadOnlyMemory<Byte>>()))
                  .Throws(exception);
 
             var configuration = new EnvironmentConfiguration();
@@ -104,6 +107,7 @@ namespace Carrot.Tests
             const UInt64 deliveryTag = 0uL;
             var model = new Mock<IModel>();
             model.Setup(_ => _.NextPublishSeqNo).Returns(deliveryTag);
+            model.Setup(_ => _.CreateBasicProperties()).Returns(BasicPropertiesStubber.Stub());
             var fallbackHandled = false;
             var configuration = new EnvironmentConfiguration();
             var resolver = new Mock<IMessageTypeResolver>();
@@ -142,7 +146,8 @@ namespace Carrot.Tests
                     .Returns(new MessageBinding("urn:message:fake",
                                                 typeof(Foo).GetTypeInfo()));
 
-            var properties = message.BuildBasicProperties(resolver.Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          resolver.Object,
                                                           dateTimeProvider.Object,
                                                           newId.Object);
             Assert.Equal(messageId, properties.MessageId);
@@ -153,7 +158,8 @@ namespace Carrot.Tests
         public void MessageType()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("urn:message:fake", properties.Type);
@@ -165,7 +171,8 @@ namespace Carrot.Tests
             const String contentEncoding = "UTF-16";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetContentEncoding(contentEncoding);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(contentEncoding, properties.ContentEncoding);
@@ -175,7 +182,8 @@ namespace Carrot.Tests
         public void DefaultContentEncoding()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("UTF-8", properties.ContentEncoding);
@@ -187,7 +195,8 @@ namespace Carrot.Tests
             const String contentType = "application/xml";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetContentType(contentType);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(contentType, properties.ContentType);
@@ -197,7 +206,8 @@ namespace Carrot.Tests
         public void DefaultContentType()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("application/json", properties.ContentType);
@@ -209,7 +219,8 @@ namespace Carrot.Tests
             String correlationId = Guid.NewGuid().ToString();
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetCorrelationId(correlationId);
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal(correlationId, properties.CorrelationId);
@@ -222,7 +233,8 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new DirectReplyConfiguration(replyExchangeName, replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("direct", properties.ReplyToAddress.ExchangeType);
@@ -237,7 +249,8 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new DirectReplyConfiguration(replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("direct:///replyRoutingKey", properties.ReplyTo);
@@ -250,7 +263,8 @@ namespace Carrot.Tests
             const String replyRoutingKey = "replyRoutingKey";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new TopicReplyConfiguration(replyExchangeName, replyRoutingKey));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("topic", properties.ReplyToAddress.ExchangeType);
@@ -265,7 +279,8 @@ namespace Carrot.Tests
             const String replyExchangeName = "replyExchangeName";
             var message = new OutboundMessage<Bar>(new Bar());
             message.SetReply(new FanoutReplyConfiguration(replyExchangeName));
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("fanout", properties.ReplyToAddress.ExchangeType);
@@ -278,7 +293,8 @@ namespace Carrot.Tests
         public void NonDurableMessage()
         {
             var message = new OutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(), 
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.False(properties.Persistent);
@@ -288,7 +304,8 @@ namespace Carrot.Tests
         public void DurableMessage()
         {
             var message = new DurableOutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(null).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(null).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.True(properties.Persistent);
@@ -299,7 +316,8 @@ namespace Carrot.Tests
         {
             var expiresAfter = new TimeSpan?(TimeSpan.FromSeconds(18));
             var message = new DurableOutboundMessage<Bar>(new Bar());
-            var properties = message.BuildBasicProperties(StubResolver<Bar>(expiresAfter).Object,
+            var properties = message.ConfigureBasicProperties(BasicPropertiesStubber.Stub(),
+                                                          StubResolver<Bar>(expiresAfter).Object,
                                                           StubDateTimeProvider().Object,
                                                           new Mock<INewId>().Object);
             Assert.Equal("18000", properties.Expiration);
@@ -346,7 +364,7 @@ namespace Carrot.Tests
             return new Mock<IDateTimeProvider>();
         }
 
-        internal class OutboundChannelWrapper : ReliableOutboundChannel
+        private class OutboundChannelWrapper : ReliableOutboundChannel
         {
             internal OutboundChannelWrapper(IModel model,
                                             EnvironmentConfiguration configuration,

--- a/src/Carrot.Tests/SubscribingConfiguration.cs
+++ b/src/Carrot.Tests/SubscribingConfiguration.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Carrot.Configuration;
 using Moq;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 using Xunit;
 
 namespace Carrot.Tests
@@ -52,10 +51,7 @@ namespace Carrot.Tests
         {
             return new BasicDeliverEventArgs
                        {
-                           BasicProperties = new BasicProperties
-                                                 {
-                                                     Headers = new Dictionary<String, Object>()
-                                                 }
+                           BasicProperties = BasicPropertiesStubber.Stub(_ => _.Headers = new Dictionary<String, Object>())
                        };
         }
     }

--- a/src/Carrot.log4net/Carrot.log4net.csproj
+++ b/src/Carrot.log4net/Carrot.log4net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>a facility which enables log4net capabilities.</Description>
     <Title>Carrot.log4net</Title>
     <PackageId>Carrot.log4net</PackageId>

--- a/src/Carrot/AtLeastOnceConsumer.cs
+++ b/src/Carrot/AtLeastOnceConsumer.cs
@@ -32,7 +32,7 @@ namespace Carrot
                                                                   }
                                                                   catch (Exception e) { result.NotifyConsumingFault(e); }
                                                                   return result;
-                                                              });
+                                                              }, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
     }
 }

--- a/src/Carrot/AtMostOnceConsumer.cs
+++ b/src/Carrot/AtMostOnceConsumer.cs
@@ -30,7 +30,7 @@ namespace Carrot
                                                                   var result = _.Result;
                                                                   result.NotifyConsumingCompletion();
                                                                   return result;
-                                                              });
+                                                              }, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
     }
 }

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net461</TargetFrameworks>
     <Description>Carrot is a .NET lightweight library that provides a couple of facilities over RabbitMQ.</Description>
 	<Title>Carrot</Title>
     <PackageId>Carrot</PackageId>

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -6,16 +6,17 @@
     <PackageId>Carrot</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <AssemblyVersion>1.1.1</AssemblyVersion>
-    <FileVersion>1.1.1</FileVersion>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
+    <FileVersion>1.2.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>copyright © Nicola Baldi (naighes) 2019</Copyright>
     <RepositoryUrl>https://github.com/naighes/Carrot.git</RepositoryUrl>
     <PackageTags>rabbitmq</PackageTags>
     <PackageReleaseNotes>
-      PublishAsync now supports exchange parameter as String.
-    </PackageReleaseNotes>
+      Updated rabbimq driver to major version 6 
+</PackageReleaseNotes>
     <PackageLicenseUrl>https://raw.githubusercontent.com/naighes/Carrot/master/LICENSE.txt</PackageLicenseUrl>
+    <Version>1.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Carrot is a .NET lightweight library that provides a couple of facilities over RabbitMQ.</Description>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet</PackageTargetFallback>
-    <Title>Carrot</Title>
+	<Title>Carrot</Title>
     <PackageId>Carrot</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
@@ -18,12 +17,8 @@
     </PackageReleaseNotes>
     <PackageLicenseUrl>https://raw.githubusercontent.com/naighes/Carrot/master/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.5'">
-    <PackageReference Include="System.AppDomain" Version="2.0.11" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Carrot/Consumer.cs
+++ b/src/Carrot/Consumer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Carrot.Messages;
 
 namespace Carrot
 {

--- a/src/Carrot/ConsumerBase.cs
+++ b/src/Carrot/ConsumerBase.cs
@@ -62,7 +62,7 @@ namespace Carrot
                                                     {
                                                         if (_.IsFaulted)
                                                             OnUnhandledException(_.Exception);
-                                                    });
+                                                    }, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         public void Dispose()

--- a/src/Carrot/ConsumerBase.cs
+++ b/src/Carrot/ConsumerBase.cs
@@ -37,7 +37,7 @@ namespace Carrot
                                                 String exchange,
                                                 String routingKey,
                                                 IBasicProperties properties,
-                                                Byte[] body)
+                                                ReadOnlyMemory<Byte> body)
         {
             base.HandleBasicDeliver(consumerTag,
                                     deliveryTag,

--- a/src/Carrot/ConsumingContext.cs
+++ b/src/Carrot/ConsumingContext.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Carrot.Messages;
+﻿using Carrot.Messages;
 
 namespace Carrot
 {

--- a/src/Carrot/Extensions/BasicPropertiesExtensions.cs
+++ b/src/Carrot/Extensions/BasicPropertiesExtensions.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Linq;
 using System.Text;
 using Carrot.Configuration;
 using Carrot.Serialization;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Framing;
 
 namespace Carrot.Extensions
 {
@@ -44,27 +42,6 @@ namespace Carrot.Extensions
                                                         String @default = "UTF-8")
         {
             return source.ContentEncoding ?? @default;
-        }
-
-        internal static IBasicProperties Clone(this IBasicProperties source)
-        {
-            return new BasicProperties
-                       {
-                           AppId = source.AppId,
-                           ClusterId = source.ClusterId,
-                           ContentEncoding = source.ContentEncoding,
-                           ContentType = source.ContentType,
-                           CorrelationId = source.CorrelationId,
-                           DeliveryMode = source.DeliveryMode,
-                           Expiration = source.Expiration,
-                           MessageId = source.MessageId,
-                           Priority = source.Priority,
-                           ReplyTo = source.ReplyTo,
-                           Timestamp = source.Timestamp,
-                           Type = source.Type,
-                           UserId = source.UserId,
-                           Headers = source.Headers.ToDictionary(_ => _.Key, _ => _.Value)
-                       };
         }
     }
 }

--- a/src/Carrot/Extensions/ConsumerExtensions.cs
+++ b/src/Carrot/Extensions/ConsumerExtensions.cs
@@ -44,7 +44,7 @@ namespace Carrot.Extensions
                                                  return BuildFailure(consumer,
                                                                      message,
                                                                      _.Exception.GetBaseException());
-                                             });
+                                             }, TaskContinuationOptions.RunContinuationsAsynchronously);
             }
             catch (Exception exception) { return Task.FromResult(BuildFailure(consumer, message, exception)); }
         }

--- a/src/Carrot/LoggedAtLeastOnceConsumer.cs
+++ b/src/Carrot/LoggedAtLeastOnceConsumer.cs
@@ -45,7 +45,7 @@ namespace Carrot
         {
             base.OnConsumerCancelled(sender, args);
 
-            _log.Info($"consumer-model basic.cancel received (consumer-tag: '{args.ConsumerTag}')");
+            _log.Info($"consumer-model basic.cancel received (consumer-tags: '{String.Join(",",args.ConsumerTags)}')");
         }
     }
 }

--- a/src/Carrot/LoggedAtLeastOnceConsumer.cs
+++ b/src/Carrot/LoggedAtLeastOnceConsumer.cs
@@ -31,7 +31,7 @@ namespace Carrot
                                                                                 IOutboundChannel outboundChannel)
         {
             return base.ConsumeAsync(args, outboundChannel)
-                       .ContinueWith(_ => _.HandleErrorResult(_log));
+                       .ContinueWith(_ => _.HandleErrorResult(_log), TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         protected override void OnUnhandledException(AggregateException exception)

--- a/src/Carrot/LoggedAtMostOnceConsumer.cs
+++ b/src/Carrot/LoggedAtMostOnceConsumer.cs
@@ -31,7 +31,7 @@ namespace Carrot
                                                                                 IOutboundChannel outboundChannel)
         {
             return base.ConsumeAsync(args, outboundChannel)
-                       .ContinueWith(_ => _.HandleErrorResult(_log));
+                       .ContinueWith(_ => _.HandleErrorResult(_log), TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         protected override void OnUnhandledException(AggregateException exception)

--- a/src/Carrot/LoggedAtMostOnceConsumer.cs
+++ b/src/Carrot/LoggedAtMostOnceConsumer.cs
@@ -45,7 +45,7 @@ namespace Carrot
         {
             base.OnConsumerCancelled(sender, args);
 
-            _log.Info($"consumer-model basic.cancel received (consumer-tag: '{args.ConsumerTag}')");
+            _log.Info($"consumer-model basic.cancel received (consumer-tags: '{String.Join(",", args.ConsumerTags)}')");
         }
     }
 }

--- a/src/Carrot/Messages/ConsumedMessage.cs
+++ b/src/Carrot/Messages/ConsumedMessage.cs
@@ -29,7 +29,7 @@ namespace Carrot.Messages
         {
             return Task.WhenAll(subscriptions.Select(_ => _.SafeConsumeAsync(this,
                                                                              outboundChannel)))
-                       .ContinueWith(AggregateResult);
+                       .ContinueWith(AggregateResult, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         private AggregateConsumingResult BuildErrorResult(IEnumerable<ConsumingResult> results)

--- a/src/Carrot/Messages/DurableOutboundMessage.cs
+++ b/src/Carrot/Messages/DurableOutboundMessage.cs
@@ -11,11 +11,12 @@ namespace Carrot.Messages
         {
         }
 
-        internal override IBasicProperties BuildBasicProperties(IMessageTypeResolver resolver,
+        internal override IBasicProperties ConfigureBasicProperties(IBasicProperties basicProperties,
+                                                                IMessageTypeResolver resolver,
                                                                 IDateTimeProvider dateTimeProvider,
                                                                 INewId idGenerator)
         {
-            var properties = base.BuildBasicProperties(resolver, dateTimeProvider, idGenerator);
+            var properties = base.ConfigureBasicProperties(basicProperties, resolver, dateTimeProvider, idGenerator);
             properties.Persistent = true;
             return properties;
         }

--- a/src/Carrot/Messages/OutboundMessage.cs
+++ b/src/Carrot/Messages/OutboundMessage.cs
@@ -5,7 +5,6 @@ using Carrot.Configuration;
 using Carrot.Extensions;
 using Carrot.Messages.Replies;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Framing;
 
 namespace Carrot.Messages
 {
@@ -57,40 +56,39 @@ namespace Carrot.Messages
             Headers.Set(HeaderCollection.ReplyConfigurationKey, replyConfiguration);
         }
 
-        internal virtual IBasicProperties BuildBasicProperties(IMessageTypeResolver resolver,
+        internal virtual IBasicProperties ConfigureBasicProperties(IBasicProperties basicProperties,
+                                                               IMessageTypeResolver resolver,
                                                                IDateTimeProvider dateTimeProvider,
                                                                INewId idGenerator)
         {
-            var properties = new BasicProperties
-                                 {
-                                     Headers = new Dictionary<String, Object>(),
-                                     Persistent = false,
-                                     ContentType = Headers.ContentType ?? SerializationConfiguration.DefaultContentType,
-                                     ContentEncoding = Headers.ContentEncoding ?? SerializationConfiguration.DefaultContentEncoding,
-                                     MessageId = Headers.MessageId ?? idGenerator.Next(),
-                                     Timestamp = new AmqpTimestamp(Headers.Timestamp <= 0L
-                                                                  ? dateTimeProvider.UtcNow().ToUnixTimestamp()
-                                                                  : Headers.Timestamp)
-                                 };
+            basicProperties.Headers = new Dictionary<String, Object>();
+            basicProperties.Persistent = false;
+            basicProperties.ContentType = Headers.ContentType ?? SerializationConfiguration.DefaultContentType;
+            basicProperties.ContentEncoding = Headers.ContentEncoding ?? SerializationConfiguration.DefaultContentEncoding;
+            basicProperties.MessageId = Headers.MessageId ?? idGenerator.Next();
+            basicProperties.Timestamp = new AmqpTimestamp(Headers.Timestamp <= 0L
+                ? dateTimeProvider.UtcNow().ToUnixTimestamp()
+                : Headers.Timestamp);
+        
 
             if (!String.IsNullOrWhiteSpace(Headers.CorrelationId))
-                properties.CorrelationId = Headers.CorrelationId;
+                basicProperties.CorrelationId = Headers.CorrelationId;
 
             if (Headers.ReplyConfiguration != null)
-                properties.ReplyTo = Headers.ReplyConfiguration.ToString();
+                basicProperties.ReplyTo = Headers.ReplyConfiguration.ToString();
 
             var binding = resolver.Resolve<TMessage>();
-            properties.Type = binding.RawName;
+            basicProperties.Type = binding.RawName;
 
             if (binding.ExpiresAfter.HasValue)
-                properties.Expiration = binding.ExpiresAfter
+                basicProperties.Expiration = binding.ExpiresAfter
                                                .GetValueOrDefault()
                                                .TotalMilliseconds
                                                .ToString(CultureInfo.InvariantCulture);
 
-            Headers.NonReservedHeaders().ForEach(_ => properties.Headers.Add(_.Key, _.Value));
+            Headers.NonReservedHeaders().ForEach(_ => basicProperties.Headers.Add(_.Key, _.Value));
 
-            return properties;
+            return basicProperties;
         }
     }
 }

--- a/src/Carrot/OutboundChannel.cs
+++ b/src/Carrot/OutboundChannel.cs
@@ -124,7 +124,7 @@ namespace Carrot
             }
             catch (Exception exception) { tcs.TrySetException(exception); }
 
-            return tcs.Task.ContinueWith(Result);
+            return tcs.Task.ContinueWith(Result, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
     }
 }

--- a/src/Carrot/OutboundChannel.cs
+++ b/src/Carrot/OutboundChannel.cs
@@ -40,6 +40,9 @@ namespace Carrot
 
             OnModelDisposing();
             Model.ModelShutdown -= OnModelShutdown;
+            const string message = "ModelContext Disposed";
+            if(Model.IsOpen)
+                Model.Close(200, message);
             Model.Dispose();
         }
 

--- a/src/Carrot/OutboundChannel.cs
+++ b/src/Carrot/OutboundChannel.cs
@@ -7,8 +7,6 @@ using RabbitMQ.Client;
 
 namespace Carrot
 {
-    using RabbitMQ.Client.Framing;
-
     public class OutboundChannel : IOutboundChannel
     {
         protected readonly IModel Model;
@@ -58,10 +56,9 @@ namespace Carrot
                                                          String exchange,
                                                          String routingKey)
         {
-            var properties = (IBasicProperties)(message.Args
-                                                       .BasicProperties as BasicProperties)?.Clone() ?? message.Args
-                                                                                                               .BasicProperties
-                                                                                                               .Clone();
+            var properties = message.Args
+                    .BasicProperties ?? message.Args.BasicProperties
+                                                                            ;
             var body = message.Args.Body;
 
             return PublishInternalAsync(exchange, routingKey, properties, body);
@@ -96,7 +93,8 @@ namespace Carrot
         protected IBasicProperties BuildBasicProperties<TMessage>(OutboundMessage<TMessage> source)
             where TMessage : class
         {
-            return source.BuildBasicProperties(Configuration.MessageTypeResolver,
+            return source.ConfigureBasicProperties(Model.CreateBasicProperties(),
+                                               Configuration.MessageTypeResolver,
                                                DateTimeProvider,
                                                Configuration.IdGenerator);
         }
@@ -115,7 +113,7 @@ namespace Carrot
         private Task<IPublishResult> PublishInternalAsync(String exchange,
                                                           String routingKey,
                                                           IBasicProperties properties,
-                                                          Byte[] body)
+                                                          ReadOnlyMemory<Byte> body)
         {
             var tcs = new TaskCompletionSource<Boolean>(properties);
 

--- a/src/Carrot/ReliableOutboundChannel.cs
+++ b/src/Carrot/ReliableOutboundChannel.cs
@@ -27,7 +27,7 @@ namespace Carrot
             Model.BasicAcks += OnModelBasicAcks;
             Model.BasicNacks += OnModelBasicNacks;
         }
-
+        
         public override Task<IPublishResult> PublishAsync<TMessage>(OutboundMessage<TMessage> source,
                                                                     Exchange exchange,
                                                                     String routingKey)

--- a/src/Carrot/ReliableOutboundChannel.cs
+++ b/src/Carrot/ReliableOutboundChannel.cs
@@ -41,7 +41,7 @@ namespace Carrot
         {
             var properties = BuildBasicProperties(source);
             var body = BuildBody(source, properties);
-            var tcs = new TaskCompletionSource<Boolean>(properties);
+            var tcs = new TaskCompletionSource<Boolean>(properties, TaskCreationOptions.RunContinuationsAsynchronously);
             var tag = Model.NextPublishSeqNo;
             _confirms.TryAdd(tag, new Tuple<TaskCompletionSource<Boolean>, IMessage>(tcs, source));
 
@@ -60,7 +60,7 @@ namespace Carrot
                 tcs.TrySetException(exception);
             }
 
-            return tcs.Task.ContinueWith(Result);
+            return tcs.Task.ContinueWith(Result, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         protected override void OnModelDisposing()

--- a/src/Carrot/ReliableOutboundChannel.cs
+++ b/src/Carrot/ReliableOutboundChannel.cs
@@ -67,7 +67,8 @@ namespace Carrot
         {
             base.OnModelDisposing();
 
-            Model.WaitForConfirms(TimeSpan.FromSeconds(30d)); // TODO: timeout should not be hardcodeds
+            if(Model.IsOpen)
+                Model.WaitForConfirms(TimeSpan.FromSeconds(30d)); // TODO: timeout should not be hardcodeds
             Model.BasicAcks -= OnModelBasicAcks;
             Model.BasicNacks -= OnModelBasicNacks;
         }

--- a/src/Carrot/Serialization/EncodingExtensions.cs
+++ b/src/Carrot/Serialization/EncodingExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Carrot.Serialization
+{
+    public static class EncodingExtensions
+    {
+        public static string GetString(this Encoding encoding, ReadOnlyMemory<byte> memory)
+        {
+            var arraySegment = GetArray(memory);
+            return encoding.GetString(arraySegment.Array ?? throw new InvalidOperationException(), 
+                                 arraySegment.Offset, arraySegment.Count);
+        }
+
+        private static ArraySegment<byte> GetArray(ReadOnlyMemory<byte> memory)
+        {
+            if (!MemoryMarshal.TryGetArray(memory, out var result))
+                throw new InvalidOperationException("Buffer backed by array was expected");
+            return result;
+        }
+    }
+}

--- a/src/Carrot/Serialization/ISerializer.cs
+++ b/src/Carrot/Serialization/ISerializer.cs
@@ -6,7 +6,7 @@ namespace Carrot.Serialization
 {
     public interface ISerializer
     {
-        Object Deserialize(Byte[] body, TypeInfo type, Encoding encoding = null);
+        Object Deserialize(ReadOnlyMemory<Byte> body, TypeInfo type, Encoding encoding = null);
 
         String Serialize(Object obj);
     }

--- a/src/Carrot/Serialization/JsonSerializer.cs
+++ b/src/Carrot/Serialization/JsonSerializer.cs
@@ -9,10 +9,10 @@ namespace Carrot.Serialization
     {
         public JsonSerializerSettings Settings { get; } = new JsonSerializerSettings();
 
-        public Object Deserialize(Byte[] body, TypeInfo type, Encoding encoding = null)
+        public object Deserialize(ReadOnlyMemory<Byte> body, TypeInfo type, Encoding encoding = null)
         {
             var e = encoding ?? new UTF8Encoding(true);
-            return JsonConvert.DeserializeObject(e.GetString(body),
+            return JsonConvert.DeserializeObject(e.GetString(body.Span.ToArray()),
                                                  type.AsType(),
                                                  Settings);
         }

--- a/src/Carrot/Serialization/JsonSerializer.cs
+++ b/src/Carrot/Serialization/JsonSerializer.cs
@@ -13,17 +13,18 @@ namespace Carrot.Serialization
         {
             var e = encoding ?? new UTF8Encoding(true);
 #if NETCOREAPP3_1
-            return JsonConvert.DeserializeObject(e.GetString(body.Span),type.AsType(),Settings);
+            
+            var json = e.GetString(body.Span);
 #else
-            return JsonConvert.DeserializeObject(e.GetString(body.ToArray()),
-                    type.AsType(),
-                    Settings);
-#endif
+            var json = e.GetString(body);
+#endif      
+            return JsonConvert.DeserializeObject(json, type.AsType(), Settings);
         }
-        
+
         public String Serialize(Object obj)
         {
             return JsonConvert.SerializeObject(obj);
         }
+        
     }
 }

--- a/src/Carrot/Serialization/JsonSerializer.cs
+++ b/src/Carrot/Serialization/JsonSerializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
@@ -12,11 +12,15 @@ namespace Carrot.Serialization
         public object Deserialize(ReadOnlyMemory<Byte> body, TypeInfo type, Encoding encoding = null)
         {
             var e = encoding ?? new UTF8Encoding(true);
-            return JsonConvert.DeserializeObject(e.GetString(body.Span.ToArray()),
-                                                 type.AsType(),
-                                                 Settings);
+#if NETCOREAPP3_1
+            return JsonConvert.DeserializeObject(e.GetString(body.Span),type.AsType(),Settings);
+#else
+            return JsonConvert.DeserializeObject(e.GetString(body.ToArray()),
+                    type.AsType(),
+                    Settings);
+#endif
         }
-
+        
         public String Serialize(Object obj)
         {
             return JsonConvert.SerializeObject(obj);

--- a/src/Carrot/Serialization/NullSerializer.cs
+++ b/src/Carrot/Serialization/NullSerializer.cs
@@ -10,9 +10,9 @@ namespace Carrot.Serialization
 
         private NullSerializer() { }
 
-        public Object Deserialize(Byte[] body,
-                                  TypeInfo type,
-                                  Encoding encoding = null)
+        public object Deserialize(ReadOnlyMemory<Byte> body,
+            TypeInfo type,
+            Encoding encoding = null)
         {
             return null;
         }


### PR DESCRIPTION
RabbitMQ dotnet driver update - some breaking changes were introduced with major release 6, as reported in changelog.
As a result minimum supported versions are now net461/netframework2.0.
Version bumped to 1.2.0 ( Carrot package only )

Notes:
BasicProperties class visibility changed - this caused so many changes to internals.