### PR TITLE
Requeue message if fallback fails

### DIFF
--- a/src/Carrot.Tests/ApplyingFallbackStrategy.cs
+++ b/src/Carrot.Tests/ApplyingFallbackStrategy.cs
@@ -35,6 +35,7 @@ namespace Carrot.Tests
                                                    default(Queue),
                                                    builder.Object,
                                                    _configuration);
+
             var result = consumer.ConsumeAsync(args,
                                                outboundChannel)
                                  .Result;
@@ -59,6 +60,7 @@ namespace Carrot.Tests
                                                    default(Queue),
                                                    builder.Object,
                                                    _configuration);
+
             var result = consumer.ConsumeAsync(args,
                                                outboundChannel)
                                  .Result;
@@ -84,13 +86,51 @@ namespace Carrot.Tests
                                                           default(Queue),
                                                           builder.Object,
                                                           _configuration);
+
             var result = consumer.CallConsumeInternalAsync(args).Result;
+
             Assert.IsType<ReiteratedConsumingFailure>(result);
             strategy.Verify(_ => _.Apply(outboundChannel, message), Times.Once);
         }
 
         [Fact]
-        public void DeadLetterExchangeStrategy()
+        public void OnReiteratedErrorFallbackFailure()
+        {
+            var inboundChannel = new Mock<IInboundChannel>();
+            var strategy = new Mock<IFallbackStrategy>();
+            var args = FakeBasicDeliverEventArgs(true);
+            var message = new FakeConsumedMessage(new Object(), args);
+            _configuration.FallbackBy((c, q) => strategy.Object);
+            _configuration.Consumes(new FakeConsumer(consumedMessage => { throw new Exception(); }));
+            var builder = new Mock<IConsumedMessageBuilder>();
+            builder.Setup(_ => _.Build(args)).Returns(message);
+            var outboundChannel = new Mock<IOutboundChannel>();
+            strategy.Setup(_ => _.Apply(outboundChannel.Object, message))
+                .ReturnsAsync(new FallbackAppliedFailure(new Exception()));
+            var consumer = new AtLeastOnceConsumerWrapper(inboundChannel.Object,
+                outboundChannel.Object,
+                default(Queue),
+                builder.Object,
+                _configuration);
+
+            var result = consumer.CallConsumeInternalAsync(args).Result;
+            
+            Assert.IsType<ReiteratedConsumingFailure>(result);
+            outboundChannel
+                .Verify(c =>
+                    c.PublishAsync(It.IsAny<OutboundMessage<FakeConsumedMessage>>(), It.IsAny<Exchange>(),
+                        It.IsAny<string>()), Times.Never);
+            outboundChannel
+                .Verify(c =>
+                    c.PublishAsync(It.IsAny<OutboundMessage<FakeConsumedMessage>>(), It.IsAny<Exchange>(),
+                        It.IsAny<string>()), Times.Never);
+            inboundChannel
+                .Verify(c =>
+                    c.NegativeAcknowledge(message.Args.DeliveryTag, It.Is<bool>(boolean => boolean.Equals(true))));
+        }
+
+        [Fact]
+        public async Task DeadLetterExchangeStrategy()
         {
             var args = FakeBasicDeliverEventArgs();
             var message = new FakeConsumedMessage(null, args);
@@ -105,18 +145,48 @@ namespace Carrot.Tests
                                                   queue,
                                                   _ => $"{_}-DeadLetter");
             var outboundChannel = new Mock<IOutboundChannel>();
-            strategy.Apply(outboundChannel.Object, message);
-            outboundChannel.Verify(_ => _.ForwardAsync(message,
-                                                       It.Is<Exchange>(__ => __.Name == dleName),
-                                                       String.Empty),
-                                   Times.Once);
+            outboundChannel.Setup(c =>
+                c.ForwardAsync(message, It.Is<Exchange>(e => e.Name == dleName),
+                    string.Empty)).ReturnsAsync(SuccessfulPublishing.FromBasicProperties(message.Args.BasicProperties));
+
+            var applied = await strategy.Apply(outboundChannel.Object, message);
+
+            Assert.True(applied.Success);
+            outboundChannel.Verify();
         }
 
-        private static BasicDeliverEventArgs FakeBasicDeliverEventArgs()
+        [Fact]
+        public async Task DeadLetterExchangeStrategyForwardError()
+        {
+            var broker = new Mock<IBroker>();
+            var queue = new Queue("queue_name");
+            Func<String, String> f = _ => $"{_}-DeadLetter";
+            var dleName = f(queue.Name);
+            broker.Setup(_ => _.DeclareDurableDirectExchange(It.Is<String>(__ => __ == dleName),
+                    It.IsAny<IDictionary<String, Object>>()))
+                .Returns(new Exchange(dleName, "direct"));
+            var strategy = DeadLetterStrategy.New(broker.Object,
+                queue,
+                _ => $"{_}-DeadLetter");
+            var message = new FakeConsumedMessage(null, FakeBasicDeliverEventArgs());
+            var outboundChannel = new Mock<IOutboundChannel>();
+            outboundChannel
+                .Setup(c => c.ForwardAsync(message, It.Is<Exchange>(e => e.Name == dleName), string.Empty))
+                .ReturnsAsync(new FailurePublishing(new Exception()))
+                .Verifiable();
+
+            var applied = await strategy.Apply(outboundChannel.Object, message);
+
+            Assert.False(applied.Success);
+            outboundChannel.Verify();
+        }
+
+        private static BasicDeliverEventArgs FakeBasicDeliverEventArgs(bool redelivered = false)
         {
             return new BasicDeliverEventArgs
             {
-                BasicProperties = BasicPropertiesStubber.Stub(_ => _.Headers = new Dictionary<String, Object>())
+                BasicProperties = BasicPropertiesStubber.Stub(_ => _.Headers = new Dictionary<String, Object>()),
+                Redelivered = redelivered
             };
         }
 

--- a/src/Carrot/Fallback/IFallbackApplied.cs
+++ b/src/Carrot/Fallback/IFallbackApplied.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Carrot.Fallback
+{
+    public interface IFallbackApplied
+    {
+        bool Success { get; }
+    }
+
+    internal class FallbackAppliedSuccessful : IFallbackApplied
+    {
+        public bool Success => true;
+    }
+
+    internal class FallbackAppliedFailure : IFallbackApplied
+    {
+        public FallbackAppliedFailure(Exception exception)
+        {
+            Exception = exception;
+        }
+
+        public Exception Exception { get; }
+        public bool Success => false;
+    }
+}

--- a/src/Carrot/Fallback/IFallbackStrategy.cs
+++ b/src/Carrot/Fallback/IFallbackStrategy.cs
@@ -1,9 +1,10 @@
+using System.Threading.Tasks;
 using Carrot.Messages;
 
 namespace Carrot.Fallback
 {
     public interface IFallbackStrategy
     {
-        void Apply(IOutboundChannel channel, ConsumedMessageBase message);
+        Task<IFallbackApplied> Apply(IOutboundChannel channel, ConsumedMessageBase message);
     }
 }

--- a/src/Carrot/Fallback/NoFallbackStrategy.cs
+++ b/src/Carrot/Fallback/NoFallbackStrategy.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Carrot.Messages;
 
 namespace Carrot.Fallback
@@ -8,6 +9,9 @@ namespace Carrot.Fallback
 
         private NoFallbackStrategy() { }
 
-        public void Apply(IOutboundChannel channel, ConsumedMessageBase message) { }
+        public Task<IFallbackApplied> Apply(IOutboundChannel channel, ConsumedMessageBase message)
+        {
+            return Task.FromResult<IFallbackApplied>(new FallbackAppliedSuccessful());
+        }
     }
 }

--- a/src/Carrot/Messages/Results.cs
+++ b/src/Carrot/Messages/Results.cs
@@ -113,8 +113,15 @@ namespace Carrot.Messages
                                                          IOutboundChannel outboundChannel,
                                                          IFallbackStrategy fallbackStrategy)
         {
-            fallbackStrategy.Apply(outboundChannel, Message);
-            return base.Reply(inboundChannel, outboundChannel, fallbackStrategy);
+            var fallbackApplied = fallbackStrategy.Apply(outboundChannel, Message)
+                .GetAwaiter()
+                .GetResult();
+
+            if(fallbackApplied.Success)
+                return base.Reply(inboundChannel, outboundChannel, fallbackStrategy);
+            
+            Message.Requeue(inboundChannel);
+            return this;
         }
     }
 


### PR DESCRIPTION
When the DeadLetterStategy is applied, the ForwarAsync method returns a Task of IPublishResult. At the moment this task is unobserved, so there is no error handling.
Our proposal is to observe the result of the ForwardAsync and when FailurePublishing occours, the message is requeued and therefore it will be possible to try again later.
In case of error the current behavior is consuming the message normally