### PR TITLE
Ensure graceful IConnection shutdown

### DIFF
--- a/src/Carrot.BasicSample/Carrot.BasicSample.csproj
+++ b/src/Carrot.BasicSample/Carrot.BasicSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461;net5.0</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.BasicSample/Carrot.BasicSample.csproj
+++ b/src/Carrot.BasicSample/Carrot.BasicSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.Benchmarks/Carrot.Benchmarks.csproj
+++ b/src/Carrot.Benchmarks/Carrot.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.NLog/Carrot.NLog.csproj
+++ b/src/Carrot.NLog/Carrot.NLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
     <Description>a facility which enables NLog capabilities.</Description>
     <Title>Carrot.NLog</Title>
     <PackageId>Carrot.NLog</PackageId>

--- a/src/Carrot.RpcSample/Carrot.RpcSample.csproj
+++ b/src/Carrot.RpcSample/Carrot.RpcSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Carrot.Tests/Carrot.Tests.csproj
+++ b/src/Carrot.Tests/Carrot.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
 </PropertyGroup>
 

--- a/src/Carrot.Tests/Carrot.Tests.csproj
+++ b/src/Carrot.Tests/Carrot.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <LangVersion>preview</LangVersion>
 </PropertyGroup>
 

--- a/src/Carrot.log4net/Carrot.log4net.csproj
+++ b/src/Carrot.log4net/Carrot.log4net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
     <Description>a facility which enables log4net capabilities.</Description>
     <Title>Carrot.log4net</Title>
     <PackageId>Carrot.log4net</PackageId>

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -2,21 +2,21 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <Description>Carrot is a .NET lightweight library that provides a couple of facilities over RabbitMQ.</Description>
-	<Title>Carrot</Title>
+    <Title>Carrot</Title>
     <PackageId>Carrot</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <AssemblyVersion>1.2.1</AssemblyVersion>
-    <FileVersion>1.2.1</FileVersion>
+    <AssemblyVersion>1.2.2</AssemblyVersion>
+    <FileVersion>1.2.2</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>copyright © Nicola Baldi (naighes) 2019</Copyright>
     <RepositoryUrl>https://github.com/naighes/Carrot.git</RepositoryUrl>
     <PackageTags>rabbitmq</PackageTags>
     <PackageReleaseNotes>
-      Requeue message if fallback fails.
-</PackageReleaseNotes>
+      Enable graceful connection shutdown
+    </PackageReleaseNotes>
     <PackageLicenseUrl>https://raw.githubusercontent.com/naighes/Carrot/master/LICENSE.txt</PackageLicenseUrl>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/Carrot/Carrot.csproj
+++ b/src/Carrot/Carrot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <Description>Carrot is a .NET lightweight library that provides a couple of facilities over RabbitMQ.</Description>
 	<Title>Carrot</Title>
     <PackageId>Carrot</PackageId>

--- a/src/Carrot/Connection.cs
+++ b/src/Carrot/Connection.cs
@@ -41,8 +41,8 @@ namespace Carrot
                 consumer.Dispose();
 
             _outboundChannel?.Dispose();
-            Cleanup(_connection, 200, "Connection Disposed");
             _connection.ConnectionShutdown -= OnConnectionShutdown;
+            Cleanup(_connection, 200, "Connection Disposed");
             _connection?.Dispose();
         }
 

--- a/src/Carrot/Serialization/JsonSerializer.cs
+++ b/src/Carrot/Serialization/JsonSerializer.cs
@@ -12,7 +12,7 @@ namespace Carrot.Serialization
         public object Deserialize(ReadOnlyMemory<Byte> body, TypeInfo type, Encoding encoding = null)
         {
             var e = encoding ?? new UTF8Encoding(true);
-#if NETCOREAPP3_1
+#if (NETCOREAPP3_1 || NET5_0)
             
             var json = e.GetString(body.Span);
 #else


### PR DESCRIPTION
This PR solves an issue observed when disposing the connection.

*  Moved netcoreapp2.0 (test/samples/benchmark) to netcoreapp2.1 version
*  Added explicit .net5.0 support
* bumped version - (minor) to 1.2.1